### PR TITLE
@ashfurrow => Sets up the CI to pass the tests, adds docs, ref #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,31 @@ WORKSPACE = Kiosk.xcworkspace
 SCHEME = Kiosk
 CONFIGURATION = Beta
 
-
-all: ci
+# Default for `make`
+all: ci 
 
 build:
-	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' -sdk iphonesimulator -destination 'name=iPad Retina' build | xcpretty -c
+	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration '$(CONFIGURATION)' -sdk iphonesimulator -destination 'name=iPad Retina' build | xcpretty -c
 
 clean:
-	xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' clean
+	xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration '$(CONFIGURATION)' clean
 
 test:
-	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration Debug test -sdk iphonesimulator -destination 'name=iPad Retina' | xcpretty -c --test
+	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug test -sdk iphonesimulator -destination 'name=iPad Retina' | xcpretty -c --test
 
-ci: CONFIGURATION = Debug
-ci:	build
+before_ci:
+	sudo xcode-select -s /Applications/Xcode6-Beta5.app/Contents/Developer
+	pod repo add artsy https://github.com/artsy/Specs.git
+	
+after_ci:
+	sudo xcode-select -s /Applications/Xcode.app/Contents/Developer	
+	
+setup:
+	bundle install
+	pod install
+
+prepare_ci: CONFIGURATION = Debug
+prepare_ci:	before_ci setup build
+	
+ci: test after_ci
+	

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the app. Once we integrate networking support, we'll figure out a way to stub
 network requests so that the app can run with sample data. 
 
 Artsy has licensed fonts for use in this app, but due to the terms of that 
-license, they are not available for open source distribution. This has required
+license, they are not available for open source distribution. This has [required](http://artsy.github.io/blog/2014/06/20/artsys-first-closed-source-pod/)
 us to use [private pods](http://guides.cocoapods.org/making/private-cocoapods.html). 
 Once we integrate these pods in, we'll provide substitutes for the open-source
 distribution. You shouldn't notice a difference. 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,18 @@
+Continuous Integration
+===========
+
+We are currently using Jenkins to run our CI with the aim to eventually switch to Travis when it adds Xcode 6 support. The vast majority of the CI work is done in our Makefile. Here's the commands being ran inside Jenkins itself:
+
+``` shell
+#!/bin/bash
+
+source ~/.bash_profile
+rm -rf /Users/joe/Library/Developer/Xcode/DerivedData
+security unlock-keychain -p [username] /Users/joe/Library/Keychains/jenkins.keychain
+
+make prepare_ci
+make ci
+
+```
+
+Under the hood we set the Xcode to the beta, run a build setup task, then a run task and switch back to the Xcode stable release. The reason for differentiating between building and testing in our steps is to reduce verbosity in reading the log in travis. 


### PR DESCRIPTION
Adds documentation around the script that gets ran on Joe ( Our Artsy CI Mac. ) Not sure if PRs get ran separately on Jenkins yet, so we might not be :green_apple:s with this PR.

Also adds some additional context around private pods in the readme.
