### PR TITLE
@ashfurrow => use DI for defaults the xauth token tests - fixes #42

### DIFF
--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -8,7 +8,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
         // Override point for customization after application launch.
 
-        Provider.sharedProvider = Provider.StubbingProvider()
+//        Provider.sharedProvider = Provider.StubbingProvider()
 
         return true
     }

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -88,7 +88,7 @@ extension ArtsyAPI : MoyaTarget {
         // Sign all non-XApp token requests
         switch target {
         case .XApp:
-            return endpoint.endpointByAddingHTTPHeaderFields(["X-Access-Token": ""])
+            return endpoint
         case .XAuth:
             return endpoint
         default:

--- a/KioskTests/TestHelpers.swift
+++ b/KioskTests/TestHelpers.swift
@@ -6,7 +6,7 @@ private enum DefaultsKeys: String {
     case TokenExpiry = "TokenExpiry"
 }
 
-let defaults = NSUserDefaults.standardUserDefaults()
+var defaults = NSUserDefaults()
 
 func clearDefaultsKeys() {
     defaults.removeObjectForKey(DefaultsKeys.TokenKey.rawValue)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WORKSPACE = Kiosk.xcworkspace
 SCHEME = Kiosk
-CONFIGURATION = Release
+CONFIGURATION = Debug
 APP_NAME = Kiosk
 
 APP_PLIST = Kiosk/Info.plist
@@ -19,7 +19,7 @@ bootstrap:
 	git submodule update
 	./submodules/ReactiveCocoa/script/bootstrap
 	bundle install
-
+	
 	@echo "\nSetting up API Keys, leave blank if you don't know."
 
 	@printf '\nWhat is your Artsy API Client Secret? '; \


### PR DESCRIPTION
Tests would leak NSUserDefaults into the app. This meant that your auth token was a test string, as we don't check that you have an incorrect auth token nothing happens.

This fixes the former issue.
