### PR TITLE
@1aurabrown => use DI through the XApp process and don't open Main Storyboard on tests

### DIFF
--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -3,38 +3,23 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
                             
-    var window: UIWindow!
+    var window: UIWindow! = UIWindow(frame:UIScreen.mainScreen().bounds)
 
     func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
-        // Override point for customization after application launch.
 
 //        Provider.sharedProvider = Provider.StubbingProvider()
+        // I couldn't figure how to swizzle this out like we do in objc.
+
+        if let inTests: AnyClass = NSClassFromString("XCTest") { return true}
+
+        let auctionStoryboard = UIStoryboard(name: "Auction", bundle: nil)
+        let rootVC = auctionStoryboard.instantiateInitialViewController() as UINavigationController
+
+        window.rootViewController = rootVC
+        window.makeKeyAndVisible()
 
         return true
     }
-
-    func applicationWillResignActive(application: UIApplication!) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(application: UIApplication!) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(application: UIApplication!) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(application: UIApplication!) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(application: UIApplication!) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
 
 }
 

--- a/Kiosk/App/Models/Artist.swift
+++ b/Kiosk/App/Models/Artist.swift
@@ -3,7 +3,7 @@ import Foundation
 class Artist: JSONAble {
 
     let id: String
-    var name: String
+    dynamic var name: String
 
     init(id: String, name: String) {
         self.id = id

--- a/Kiosk/App/Models/Artwork.swift
+++ b/Kiosk/App/Models/Artwork.swift
@@ -4,21 +4,23 @@ class Artwork: JSONAble {
     let id: String
 
     let dateString: String
-    let title: String
-    let name: String
-    let blurb: String
+    dynamic let title: String
+    dynamic let name: String
+    dynamic let blurb: String
+    dynamic let price: String
 
-    var artists: [Artist]?
-    var culturalMarker: String?
+    dynamic var artists: [Artist]?
+    dynamic var culturalMarker: String?
 
-    var images: [Image]?
+    dynamic var images: [Image]?
 
-    init(id: String, dateString: String, title: String, name: String, blurb: String) {
+    init(id: String, dateString: String, title: String, name: String, blurb: String, price: String) {
         self.id = id
         self.dateString = dateString
         self.title = title
         self.name = name
         self.blurb = blurb
+        self.price = price
     }
 
     override class func fromJSON(json: [String: AnyObject]) -> JSONAble {
@@ -29,8 +31,9 @@ class Artwork: JSONAble {
         let title = json["title"].stringValue
         let dateString = json["date"].stringValue
         let blurb = json["blurb"].stringValue
+        let price = json["price"].stringValue
 
-        let artwork = Artwork(id: id, dateString: dateString, title: title, name: name, blurb: blurb)
+        let artwork = Artwork(id: id, dateString: dateString, title: title, name: name, blurb: blurb, price: price)
 
         if let artistDictionary = json["artist"].object as? [String: AnyObject] {
             artwork.artists = [Artist.fromJSON(artistDictionary) as Artist]

--- a/Kiosk/App/Networking/XAppAuthentication.swift
+++ b/Kiosk/App/Networking/XAppAuthentication.swift
@@ -1,10 +1,12 @@
 import Foundation
 
 /// Request to fetch and store new XApp token if the current token is missing or expired.
-private func XAppTokenRequest() -> RACSignal {
+
+private func XAppTokenRequest(defaults: NSUserDefaults) -> RACSignal {
 
     // I don't like an extension of a class referencing what is essentially a singleton of that class.
-    var appToken = XAppToken()
+    var appToken = XAppToken(defaults: defaults)
+
     let newTokenSignal = Provider.sharedProvider.request(ArtsyAPI.XApp, parameters: ArtsyAPI.XApp.defaultParameters).filterSuccessfulStatusCodes().mapJSON().doNext({ (response) -> Void in
         if let dictionary = response as? NSDictionary {
             let formatter = ISO8601DateFormatter()
@@ -20,11 +22,14 @@ private func XAppTokenRequest() -> RACSignal {
     return RACSignal.`if`(validTokenSignal, then: RACSignal.empty(), `else`: newTokenSignal)
 }
 
+
 /// Request to fetch a given target. Ensures that valid XApp tokens exist before making request
-func XAppRequest(token: ArtsyAPI, method: Moya.Method = Moya.DefaultMethod(), parameters: [String: AnyObject] = Moya.DefaultParameters()) -> RACSignal {
-    
+
+func XAppRequest(token: ArtsyAPI, method: Moya.Method = Moya.DefaultMethod(), parameters: [String: AnyObject] = Moya.DefaultParameters(), defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults()) -> RACSignal {
+
     // First perform XAppTokenRequest(). When it completes, then the signal returned from the closure will be subscribed to.
-    return XAppTokenRequest().then({ () -> RACSignal! in
+
+    return XAppTokenRequest(defaults).then({ () -> RACSignal! in
         return Provider.sharedProvider.request(token, method: method, parameters: parameters)
     })
 }

--- a/Kiosk/App/Networking/XAppToken.swift
+++ b/Kiosk/App/Networking/XAppToken.swift
@@ -12,15 +12,20 @@ struct XAppToken {
         case TokenKey = "TokenKey"
         case TokenExpiry = "TokenExpiry"
     }
-    
-    private let defaults = NSUserDefaults.standardUserDefaults()
-        
+
     // MARK: - Initializers
 
-    init() {
-        // Empty, but necessary to invoke from tests
+    let defaults:NSUserDefaults
+
+    init(defaults:NSUserDefaults) {
+        self.defaults = defaults
     }
-    
+
+    init() {
+        self.defaults = NSUserDefaults.standardUserDefaults()
+    }
+
+
     // MARK: - Properties
     
     var token: String? {

--- a/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
@@ -10,6 +10,10 @@ class PlaceBidViewController: UIViewController {
     @IBOutlet var currentBidLabel: UILabel!
     @IBOutlet var nextBidAmountLabel: UILabel!
 
+    @IBOutlet var artistNameLabel: ARSerifLabel!
+    @IBOutlet var artworkTitleLabel: ARSerifLabel!
+    @IBOutlet var artworkPriceLabel: ARSerifLabel!
+
     var saleArtwork: SaleArtwork?
 
     class func instantiateFromStoryboard() -> PlaceBidViewController {
@@ -39,6 +43,10 @@ class PlaceBidViewController: UIViewController {
         if let saleArtwork:SaleArtwork = self.saleArtwork {
             RAC(currentBidLabel, "text") <~ RACObserve(saleArtwork, "openingBidCents").map(toCurrentBidString)
             RAC(nextBidAmountLabel, "text") <~ RACObserve(saleArtwork, "openingBidCents").map(toOpeningBidString)
+
+            RAC(artistNameLabel, "text") <~ RACObserve(saleArtwork.artwork.artists?.first, "name")
+            RAC(artworkTitleLabel, "text") <~ RACObserve(saleArtwork.artwork, "title")
+            RAC(artworkPriceLabel, "text") <~ RACObserve(saleArtwork.artwork, "price")
         }
     }
 

--- a/Kiosk/Bid Fulfillment/UserCreationViewController.swift
+++ b/Kiosk/Bid Fulfillment/UserCreationViewController.swift
@@ -10,5 +10,4 @@ public class UserCreationViewController: UIViewController {
         self.performSegue(.ToConfirmUserCreation)
     }
 
-
 }

--- a/Kiosk/Storyboards/Fulfillment.storyboard
+++ b/Kiosk/Storyboards/Fulfillment.storyboard
@@ -260,20 +260,20 @@
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Your Bid: $10,000" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="v7X-dR-pia" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="448" width="166" height="29"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Estimate: $10,000" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="v7X-dR-pia" customClass="ARSerifLabel">
+                                <rect key="frame" x="65" y="447" width="364" height="29"/>
                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="16"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ROY LICHTENSTEIN" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="h2j-OF-Phh" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="388" width="166" height="29"/>
+                                <rect key="frame" x="65" y="388" width="364" height="29"/>
                                 <fontDescription key="fontDescription" name="AvantGardeGothicITCW01Dm" family="Avant Garde Gothic ITCW01Dm" pointSize="15"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Crying Girl, 1963" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="Aj2-T3-pNw" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="416" width="166" height="29"/>
+                                <rect key="frame" x="65" y="416" width="364" height="29"/>
                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="16"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
@@ -286,6 +286,9 @@
                     </view>
                     <navigationItem key="navigationItem" id="AXh-zM-wkr"/>
                     <connections>
+                        <outlet property="artistNameLabel" destination="h2j-OF-Phh" id="uix-5k-rFx"/>
+                        <outlet property="artworkPriceLabel" destination="v7X-dR-pia" id="ddn-gN-BWR"/>
+                        <outlet property="artworkTitleLabel" destination="Aj2-T3-pNw" id="3FZ-B6-AkR"/>
                         <outlet property="bidAmountTextField" destination="GJN-vx-0ge" id="Wpe-9v-QCg"/>
                         <outlet property="bidButton" destination="dT1-U2-hie" id="b1u-df-a4J"/>
                         <outlet property="currentBidLabel" destination="GS2-EK-4Nx" id="Wi1-Uq-gkb"/>

--- a/Kiosk/Stubbed Responses/XApp.json
+++ b/Kiosk/Stubbed Responses/XApp.json
@@ -1,1 +1,1 @@
-{"xapp_token":"some token that never expires","expires_in":"2024-09-19T12:22:21.570Z"}
+{"xapp_token":"STUBBED TOKEN!","expires_in":"2024-09-19T12:22:21.570Z"}

--- a/Kiosk/Supporting Files/Info.plist
+++ b/Kiosk/Supporting Files/Info.plist
@@ -38,8 +38,6 @@
 		<string>ITC_Avant_Garde_Gothic__Demi.ttf</string>
 		<string>AGaramondPro-Semibold.otf</string>
 	</array>
-	<key>UIMainStoryboardFile~ipad</key>
-	<string>Auction</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/KioskTests/ArtsyAPISpec.swift
+++ b/KioskTests/ArtsyAPISpec.swift
@@ -9,8 +9,16 @@ func beInTheFuture() -> MatcherFunc<NSDate> {
     }
 }
 
+var defaults = NSUserDefaults()
+
 class ArtsyAPISpec: QuickSpec {
+
     override func spec() {
+
+        func newXAppRequest() -> RACSignal {
+            return XAppRequest(ArtsyAPI.Auctions, method: Moya.DefaultMethod(), parameters: Moya.DefaultParameters(), defaults: defaults)
+        }
+
         describe("keys", { () -> () in
             it("stubs responses for invalid keys") {
                 let invalidKeys = APIKeys(key: "", secret: "")
@@ -37,11 +45,12 @@ class ArtsyAPISpec: QuickSpec {
             }
             
             it("returns some data") {
-                setDefaultsKeys(nil, nil)
+                setDefaultsKeys(defaults, nil, nil)
                 
                 var called = false
+
                 // Make any XApp request, doesn't matter which, but make sure to subscribe so it actually fires
-                XAppRequest(.Auctions).subscribeNext({ (object) -> Void in
+                newXAppRequest().subscribeNext({ (object) -> Void in
                     called = true
                 })
                 
@@ -49,29 +58,29 @@ class ArtsyAPISpec: QuickSpec {
             }
             
             it("gets XApp token if it doesn't exist yet") {
-                setDefaultsKeys(nil, nil)
+                setDefaultsKeys(defaults, nil, nil)
                 
-                XAppRequest(.Auctions).subscribeNext({ (object) -> Void in
+                newXAppRequest().subscribeNext({ (object) -> Void in
                     // nop
                 })
                 
                 let past = NSDate(timeIntervalSinceNow: -1000)
-                expect(getDefaultsKeys().key).to(equal("some token that never expires"))
-                expect(getDefaultsKeys().expiry).toNot(beNil())
-                expect(getDefaultsKeys().expiry ?? past).to(beInTheFuture())
+                expect(getDefaultsKeys(defaults).key).to(equal("STUBBED TOKEN!"))
+                expect(getDefaultsKeys(defaults).expiry).toNot(beNil())
+                expect(getDefaultsKeys(defaults).expiry ?? past).to(beInTheFuture())
             }
             
             it("gets XApp token if it has expired") {
                 let past = NSDate(timeIntervalSinceNow: -1000)
-                setDefaultsKeys("some expired key", past)
+                setDefaultsKeys(defaults, "some expired key", past)
                 
-                XAppRequest(.Auctions).subscribeNext({ (object) -> Void in
+                newXAppRequest().subscribeNext({ (object) -> Void in
                     // nop
                 })
                 
-                expect(getDefaultsKeys().key).to(equal("some token that never expires"))
-                expect(getDefaultsKeys().expiry).toNot(beNil())
-                expect(getDefaultsKeys().expiry ?? past).to(beInTheFuture())
+                expect(getDefaultsKeys(defaults).key).to(equal("STUBBED TOKEN!"))
+                expect(getDefaultsKeys(defaults).expiry).toNot(beNil())
+                expect(getDefaultsKeys(defaults).expiry ?? past).to(beInTheFuture())
             }
         }
     }

--- a/KioskTests/ListViewControllerTests.swift
+++ b/KioskTests/ListViewControllerTests.swift
@@ -7,13 +7,14 @@ class ListingsViewControllerTests: QuickSpec {
         it("presents a view controller when showModal is called") {
             // As it's a UINav it needs to be in the real view herarchy 
             
-            let window = UIApplication.sharedApplication().delegate!.window!
+            let window = UIWindow(frame:UIScreen.mainScreen().bounds)
             let sut = ListingsViewController()
-            window!.rootViewController = sut
+            window.rootViewController = sut
+            window.makeKeyAndVisible()
 
             sut.allowAnimations = false;
 
-            let artwork = Artwork(id: "", dateString: "", title: "", name: "", blurb: "")
+            let artwork = Artwork(id: "", dateString: "", title: "", name: "", blurb: "", price: "")
             let saleArtwork = SaleArtwork(id: "", artwork: artwork)
             sut.presentModalForSaleArtwork(saleArtwork)
             

--- a/KioskTests/TestHelpers.swift
+++ b/KioskTests/TestHelpers.swift
@@ -6,21 +6,19 @@ private enum DefaultsKeys: String {
     case TokenExpiry = "TokenExpiry"
 }
 
-var defaults = NSUserDefaults()
-
-func clearDefaultsKeys() {
+func clearDefaultsKeys(defaults: NSUserDefaults) {
     defaults.removeObjectForKey(DefaultsKeys.TokenKey.rawValue)
     defaults.removeObjectForKey(DefaultsKeys.TokenExpiry.rawValue)
 }
 
-func getDefaultsKeys() -> (key: String?, expiry: NSDate?) {
+func getDefaultsKeys(defaults: NSUserDefaults) -> (key: String?, expiry: NSDate?) {
     let key = defaults.objectForKey(DefaultsKeys.TokenKey.rawValue) as String?
     let expiry = defaults.objectForKey(DefaultsKeys.TokenExpiry.rawValue) as NSDate?
     
     return (key: key, expiry: expiry)
 }
 
-func setDefaultsKeys(key: String?, expiry: NSDate?) {
+func setDefaultsKeys(defaults: NSUserDefaults, key: String?, expiry: NSDate?) {
     defaults.setObject(key, forKey: DefaultsKeys.TokenKey.rawValue)
     defaults.setObject(expiry, forKey: DefaultsKeys.TokenExpiry.rawValue)
 }

--- a/KioskTests/XAppTokenSpec.swift
+++ b/KioskTests/XAppTokenSpec.swift
@@ -3,12 +3,13 @@ import Nimble
 
 class XAppTokenSpec: QuickSpec {
     override func spec() {
+        let defaults = NSUserDefaults()
         let token = XAppToken()
         
         it("returns correct data") {
             let key = "some key"
             let expiry = NSDate(timeIntervalSinceNow: 1000)
-            setDefaultsKeys(key, expiry)
+            setDefaultsKeys(defaults, key, expiry)
             
             expect(token.token).to(equal(key))
             expect(token.expiry).to(equal(expiry))
@@ -17,7 +18,7 @@ class XAppTokenSpec: QuickSpec {
         it("correctly calculates validity for expired tokens") {
             let key = "some key"
             let past = NSDate(timeIntervalSinceNow: -1000)
-            setDefaultsKeys(key, past)
+            setDefaultsKeys(defaults, key, past)
             
             expect(token.isValid).to(beFalsy())
         }
@@ -25,7 +26,7 @@ class XAppTokenSpec: QuickSpec {
         it("correctly calculates validity for non-expired tokens") {
             let key = "some key"
             let future = NSDate(timeIntervalSinceNow: 1000)
-            setDefaultsKeys(key, future)
+            setDefaultsKeys(defaults, key, future)
             
             expect(token.isValid).to(beTruthy())
         }
@@ -33,13 +34,13 @@ class XAppTokenSpec: QuickSpec {
         it("correctly calculates validity for empty keys") {
             let key = ""
             let future = NSDate(timeIntervalSinceNow: 1000)
-            setDefaultsKeys(key, future)
+            setDefaultsKeys(defaults, key, future)
             
             expect(token.isValid).to(beFalsy())
         }
         
         it("properly calculates validity for missing tokens") {
-            setDefaultsKeys(nil, nil)
+            setDefaultsKeys(defaults, nil, nil)
             
             expect(token.isValid).to(beFalsy())
         }


### PR DESCRIPTION
My earlier stab at this was half-hearted, there's a lot of global grabbing of `standardUserDefaults` - I've DI'd it out for our tests.

Due to restrictions on cross target runtime manipulation I've had to stop the app delegates methods from just running outright in the app delegate
