### PR TITLE
@1aurarown => Added more safety.

### DIFF
--- a/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
@@ -44,7 +44,9 @@ class PlaceBidViewController: UIViewController {
             RAC(currentBidLabel, "text") <~ RACObserve(saleArtwork, "openingBidCents").map(toCurrentBidString)
             RAC(nextBidAmountLabel, "text") <~ RACObserve(saleArtwork, "openingBidCents").map(toOpeningBidString)
 
-            RAC(artistNameLabel, "text") <~ RACObserve(saleArtwork.artwork.artists?.first, "name")
+            if let artist = saleArtwork.artwork.artists?.first {
+                RAC(artistNameLabel, "text") <~ RACObserve(artist, "name")
+            }
             RAC(artworkTitleLabel, "text") <~ RACObserve(saleArtwork.artwork, "title")
             RAC(artworkPriceLabel, "text") <~ RACObserve(saleArtwork.artwork, "price")
         }


### PR DESCRIPTION
Basically, in some tests, the sale artwork's artwork would have a `nil` artist, so the tests would crash. Probably not an issue in the real world, but why not be safer?
