### PR TITLE
@orta => Fixes subtle problem with RAC binding.

### DIFF
--- a/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
@@ -34,7 +34,7 @@ class PlaceBidViewController: UIViewController {
             return NSNumberFormatter.currencyStringForCents(bid as Float * 100.0)
         })
 
-        RAC(bidAmountTextField, "text") <~ RACSignal.`if`(bidIsZeroSignal, then: RACSignal.`return`(""), `else`: formattedBidTextSignal)
+        RAC(bidAmountTextField, "text") <~ RACSignal.`if`(bidIsZeroSignal, then: RACSignal.defer{ RACSignal.`return`("") }, `else`: formattedBidTextSignal)
 
         keypadSignal.subscribeNext(addDigitToBid)
         deleteSignal.subscribeNext(deleteBid)


### PR DESCRIPTION
Went looking for an example to point you to on how to use this. Basically, the signal created by `return` immediately completes, so if the `if` signal changes to `true`, then the whole thing would complete and the subscription would be over. Instead, we want to _not_ complete, but rather create a new signal every time it's switched to using `defer`. 
