### PR TITLE
@orta => Made sale artwork estimates more robust.

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5E04BF3519DD98B000687199 /* SaleArtworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E04BF3419DD98B000687199 /* SaleArtworkTests.swift */; };
 		5E08488E19D06EE60078C571 /* Auctions.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E08488C19D06EE60078C571 /* Auctions.json */; };
 		5E08489B19D070DC0078C571 /* AuctionListings.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E08489919D070DC0078C571 /* AuctionListings.json */; };
 		5E0D702C19DADD8E0005AF46 /* TableCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF2C0C519DAC18000263137 /* TableCollectionViewCell.swift */; };
@@ -342,6 +343,7 @@
 		3AC32AD043F3010C4064D172 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		46ACE072A30FD791981A83FC /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		4A43B593C169F6607C344ABF /* Pods-KioskTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KioskTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KioskTests/Pods-KioskTests.release.xcconfig"; sourceTree = "<group>"; };
+		5E04BF3419DD98B000687199 /* SaleArtworkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaleArtworkTests.swift; sourceTree = "<group>"; };
 		5E08488C19D06EE60078C571 /* Auctions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = Auctions.json; path = "Stubbed Responses/Auctions.json"; sourceTree = "<group>"; };
 		5E08489919D070DC0078C571 /* AuctionListings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = AuctionListings.json; path = "Stubbed Responses/AuctionListings.json"; sourceTree = "<group>"; };
 		5E2765EC19940F3F0003BAFA /* KioskTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "KioskTests-Bridging-Header.h"; path = "../KioskTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -747,6 +749,7 @@
 				60212C9C19D5EAF9001921E1 /* ArtworkTests.swift */,
 				60212C9F19D5F20C001921E1 /* ArtistTests.swift */,
 				60212CA119D5F468001921E1 /* ImageTests.swift */,
+				5E04BF3419DD98B000687199 /* SaleArtworkTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1431,6 +1434,7 @@
 				60A3BBE519B9F14C00EF3907 /* ListViewControllerTests.swift in Sources */,
 				6030A11E19D1A23100B934CA /* Moya+ReactiveCocoa.swift in Sources */,
 				6030A10419D1931400B934CA /* ConfirmYourBidPINViewController.swift in Sources */,
+				5E04BF3519DD98B000687199 /* SaleArtworkTests.swift in Sources */,
 				5EA65C1019D5FC9B005EA4B4 /* UIView+BooleanDependentAnimation.m in Sources */,
 				5E95FCC019D99DB5004D0C8F /* Constants.swift in Sources */,
 				60A8E7CF19BE5B7F0088ACEC /* FulfillmentContainerViewControllerTests.swift in Sources */,

--- a/Kiosk/App/Models/SaleArtwork.swift
+++ b/Kiosk/App/Models/SaleArtwork.swift
@@ -69,6 +69,12 @@ class SaleArtwork: JSONAble {
             let lowDollars = NSNumberFormatter.currencyStringForCents(lowCents)
             let highDollars = NSNumberFormatter.currencyStringForCents(highCents)
             return "Estimate: \(lowDollars)–\(highDollars)"
+        case let (.Some(lowCents), nil):
+            let lowDollars = NSNumberFormatter.currencyStringForCents(lowCents)
+            return "Estimate: \(lowDollars)"
+        case let (nil, .Some(highCents)):
+            let highDollars = NSNumberFormatter.currencyStringForCents(highCents)
+            return "Estimate: \(highDollars)"
         default:
             return "No Estimate"
         }

--- a/KioskTests/Models/SaleArtworkTests.swift
+++ b/KioskTests/Models/SaleArtworkTests.swift
@@ -1,0 +1,34 @@
+import Quick
+import Nimble
+
+class SaleArtworkTests: QuickSpec {
+    override func spec() {
+        describe("estimates") {
+            var saleArtwork: SaleArtwork!
+            beforeEach {
+                let artwork = Artwork(id: "id", dateString: "Some date", title: "Art", name: "Art", blurb: "Here's some art.", price: "100", date: "2014")
+                saleArtwork = SaleArtwork(id: "id", artwork: artwork)
+            }
+            
+            it("gives no estimtates when no estimates present") {
+                expect(saleArtwork.estimateString) == "No Estimate"
+            }
+            
+            it("gives estimtates when low and high are present") {
+                saleArtwork.lowEstimateCents = 100_00
+                saleArtwork.highEstimateCents = 200_00
+                expect(saleArtwork.estimateString) == "Estimate: $100–$200"
+            }
+            
+            it("gives estimtates when low is present") {
+                saleArtwork.lowEstimateCents = 100_00
+                expect(saleArtwork.estimateString) == "Estimate: $100"
+            }
+            
+            it("gives estimtates when high is present") {
+                saleArtwork.highEstimateCents = 200_00
+                expect(saleArtwork.estimateString) == "Estimate: $200"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Handles the case where only one of the low/high estimates are present. 

![Robust](http://i.imgur.com/RJrPP7z.gif)
