### PR TITLE
@1aurabrown => deployment setup

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		60D976E719D3123B00DE9F3D /* SaleArtwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaleArtwork.swift; sourceTree = "<group>"; };
 		60D976E919D3135200DE9F3D /* Sale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sale.swift; sourceTree = "<group>"; };
 		60D976EB19D3172D00DE9F3D /* SystemTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemTime.swift; sourceTree = "<group>"; };
+		60E0332819DDAFF80096C86C /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = docs/CHANGELOG.md; sourceTree = SOURCE_ROOT; };
 		60E5553A19DAB75000F664CE /* deployment.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = deployment.md; sourceTree = "<group>"; };
 		60F0C89A19D2CA4D002B0F10 /* SimulatorOnlyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimulatorOnlyView.swift; sourceTree = "<group>"; };
 		60F104E319C0FB93002FF30C /* StoryboardIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardIdentifiers.swift; sourceTree = "<group>"; };
@@ -550,6 +551,7 @@
 		5E59DD3219913DD800A48370 /* Kiosk */ = {
 			isa = PBXGroup;
 			children = (
+				60E0332819DDAFF80096C86C /* CHANGELOG.md */,
 				60C37DCE19D43E49002E7A44 /* Kiosk.playground */,
 				60C620E419D1831D0024D493 /* Docs */,
 				5E4B56DC19C079C0002E6FCB /* Submodules */,

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -18,6 +18,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.rootViewController = rootVC
         window.makeKeyAndVisible()
 
+        let keys = EidolonKeys()
+        ARAnalytics.setupWithAnalytics([
+            ARHockeyAppBetaID: keys.hockeyBetaSecret(),
+            ARHockeyAppLiveID: keys.hockeyProductionSecret(),
+            ARMixpanelToken: keys.mixpanelProductionAPIClientKey()
+        ])
+
         return true
     }
 

--- a/Kiosk/Storyboards/Auction.storyboard
+++ b/Kiosk/Storyboards/Auction.storyboard
@@ -7,7 +7,9 @@
         <!--Navigation Controller-->
         <scene sceneID="gwf-cv-uMQ">
             <objects>
-                <navigationController id="2lC-Vc-1XS" sceneMemberID="viewController">
+                <navigationController navigationBarHidden="YES" id="2lC-Vc-1XS" sceneMemberID="viewController">
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="I8d-rj-Xv9">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Kiosk/Supporting Files/Info.plist
+++ b/Kiosk/Supporting Files/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2014.09.29</string>
+	<string>2014.10.02</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bootstrap:
 	git submodule update
 	./submodules/ReactiveCocoa/script/bootstrap
 	bundle install
-	
+
 	@echo "\nSetting up API Keys, leave blank if you don't know."
 
 	@printf '\nWhat is your Artsy API Client Secret? '; \
@@ -29,6 +29,14 @@ bootstrap:
 	@printf '\nWhat is your Artsy API Client Key? '; \
 		read ARTSY_CLIENT_KEY; \
 		bundle exec pod keys set ArtsyAPIClientKey "$$ARTSY_CLIENT_KEY"
+
+	@printf '\nWhat is your Hockey Production Secret? '; \
+		read HOCKEYPRODUCTIONSECRET; \
+		bundle exec pod keys set HockeyProductionSecret "$$HOCKEYPRODUCTIONSECRET"
+
+	@printf '\nWhat is your Hockey Beta Secret? '; \
+		read HOCKEYBETASECRET; \
+		bundle exec pod keys set HockeyBetaSecret "$$HOCKEYBETASECRET"
 
 	@printf '\nWhat is your production Mixpanel API Key? '; \
 		read MIXPANEL_KEY; \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# End User Changes
+
+### 0.0.2 - 2 Oct 2014
+
+* Artwork Listings can be browsed - @ash
+* Most confirm / enter buttons now show they're disabled - @orta
+* Bid fulfilment shows in a popover - @orta
+* Bid Fulfillment flow is prototypical via the bottom buttons - @orta
+* Analytics / Hockey setup - @orta


### PR DESCRIPTION
- Added references to Hockey and Mixpanel in our Analytics.
- Adds end user based changelog for deployment
- Hides initial app navigation bar

_You will have missing CocoaPods-Keys values after this PR_ /cc @AshFurrow 
run: `bundle exec pod keys set HockeyBetaSecret XXX` and `bundle exec pod keys set HockeyProductionSecret YYY` to bring yourself up to date. 
