### PR TITLE
@orta => get rid of purple selected state on help button

### DIFF
--- a/Kiosk/App/Views/Button Subclasses/Button.swift
+++ b/Kiosk/App/Views/Button Subclasses/Button.swift
@@ -59,7 +59,6 @@ public class MenuButton: ARMenuButton {
         if let titleLabel = titleLabel {
             titleLabel.font = titleLabel.font.fontWithSize(12)
         }
-        setBackgroundColor(UIColor.artsyPurple(), forState: .Highlighted, animated: false)
     }
 
     public override func layoutSubviews() {


### PR DESCRIPTION
:( I went through some trouble to make this button inherit from ARFlatButton, which supports different background colors for different states, but all for naught. fixes https://github.com/artsy/eidolon/issues/141
