### PR TITLE
@orta => Modified ~> operators.

### DIFF
--- a/Kiosk/App/ReactiveCocoaBindings.swift
+++ b/Kiosk/App/ReactiveCocoaBindings.swift
@@ -23,14 +23,14 @@ public struct RAC  {
 }
 
 infix operator <~ {}
-public func <~ (rac: RAC, signal: RACSignal) {
-    signal ~> rac
+public func <~ (rac: RAC, signal: RACSignal) -> RACDisposable {
+    return signal ~> rac
 }
 
-public func ~> (signal: RACSignal, rac: RAC) {
-    rac.assignSignal(signal)
+public func ~> (signal: RACSignal, rac: RAC) -> RACDisposable {
+    return rac.assignSignal(signal)
 }
 
-public func RACObserve(target: NSObject!, keyPath: String) -> RACSignal  {
+public func RACObserve(target: NSObject!, keyPath: String) -> RACSignal {
     return target.rac_valuesForKeyPath(keyPath, observer: target)
 }


### PR DESCRIPTION
Just a simple change to return the `RACDisposable` while using the operator, which was already being created, but just not returned. 

My Xcode is a bit borked atm due to my earlier Yosemite adventure, but I don't foresee this change introducing any problems. 

So now you can do stuff like:

``` swift
let subscription = RAC(newUserCredentials, "email") <~ emailTextSignal

...

subscription.dispose() // ends the binding
```
