### PR TITLE
@ashfurrow => standardise staging and the default auction id

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		5EF2C0C619DAC18000263137 /* TableCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF2C0C519DAC18000263137 /* TableCollectionViewCell.swift */; };
 		5EF2C0C819DAC3F400263137 /* MasonryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF2C0C719DAC3F400263137 /* MasonryCollectionViewCell.swift */; };
 		6007B42519DEFAA000EDF43E /* ConfirmYourBidPINViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6007B42419DEFAA000EDF43E /* ConfirmYourBidPINViewControllerTests.swift */; };
+		600AAEB819F18C3300506283 /* AppSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600AAEB719F18C3300506283 /* AppSetup.swift */; };
 		600DABE619EB41D800278378 /* RegistrationNetworkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DABE519EB41D800278378 /* RegistrationNetworkModel.swift */; };
 		600DABE719EB41D800278378 /* RegistrationNetworkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DABE519EB41D800278378 /* RegistrationNetworkModel.swift */; };
 		600DABE919EB4A5000278378 /* RegisterCard.json in Resources */ = {isa = PBXBuildFile; fileRef = 600DABE819EB4A5000278378 /* RegisterCard.json */; };
@@ -454,6 +455,7 @@
 		5EF2C0C519DAC18000263137 /* TableCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TableCollectionViewCell.swift; path = "Auction Listings/TableCollectionViewCell.swift"; sourceTree = "<group>"; };
 		5EF2C0C719DAC3F400263137 /* MasonryCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MasonryCollectionViewCell.swift; path = "Auction Listings/MasonryCollectionViewCell.swift"; sourceTree = "<group>"; };
 		6007B42419DEFAA000EDF43E /* ConfirmYourBidPINViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmYourBidPINViewControllerTests.swift; sourceTree = "<group>"; };
+		600AAEB719F18C3300506283 /* AppSetup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSetup.swift; sourceTree = "<group>"; };
 		600DABE519EB41D800278378 /* RegistrationNetworkModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationNetworkModel.swift; sourceTree = "<group>"; };
 		600DABE819EB4A5000278378 /* RegisterCard.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = RegisterCard.json; sourceTree = "<group>"; };
 		600DABED19EB657100278378 /* AdminPanelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdminPanelViewController.swift; sourceTree = "<group>"; };
@@ -1010,6 +1012,7 @@
 				6083CC2119CAF97000CFBA05 /* Card Handling */,
 				6092C4AD19CAEF75003BE8EC /* Extensions */,
 				6086143919BA303700699FBC /* Views */,
+				600AAEB719F18C3300506283 /* AppSetup.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1611,6 +1614,7 @@
 				6017320F19CF259400A58B63 /* CardHandler.swift in Sources */,
 				6024DD5E19D8286B008E600A /* UIStoryboardSegueExtensions.swift in Sources */,
 				6092C4AF19CAEF9A003BE8EC /* UIViewControllerExtensions.swift in Sources */,
+				600AAEB819F18C3300506283 /* AppSetup.swift in Sources */,
 				609A849719E53ED200476A94 /* RACFunctions.swift in Sources */,
 				60D976E819D3123B00DE9F3D /* SaleArtwork.swift in Sources */,
 				5E3D9D3219EBFCA8001C72C4 /* AppDelegate+Help.swift in Sources */,

--- a/Kiosk/Admin/AdminPanelViewController.swift
+++ b/Kiosk/Admin/AdminPanelViewController.swift
@@ -13,7 +13,9 @@ class AdminPanelViewController: UIViewController {
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue == .LoadAdminWebViewController {
             let webVC = segue.destinationViewController as WebViewController
-            webVC.URL = NSURL(string: "https://staging.artsy.net/feature/ici-live-auction")!
+            let auctionID = AppSetup.sharedState.auctionID
+            let base = AppSetup.sharedState.useStaging ? "staging.artsy.net" : "artsy.net"
+            webVC.URL = NSURL(string: "https://\(base)/feature/\(auctionID)")!
         }
     }
 }

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-let AuctionID = "ici-live-auction"
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
@@ -28,11 +26,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ARHockeyAppLiveID: keys.hockeyProductionSecret(),
             ARMixpanelToken: keys.mixpanelProductionAPIClientKey()
         ])
-        
+
+        removeXAppToken()
         setupHelpButton()
         setupUserAgent()
 
         return true
+    }
+
+    func removeXAppToken() {
+        NSUserDefaults.standardUserDefaults().removeObjectForKey("TokenKey")
     }
 
     func setupUserAgent() {

--- a/Kiosk/App/AppSetup.swift
+++ b/Kiosk/App/AppSetup.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+class AppSetup {
+
+    let auctionID = "ici-live-auction"
+    let useStaging = true
+
+    class var sharedState : AppSetup {
+        struct Static {
+            static let instance : AppSetup = AppSetup()
+        }
+        return Static.instance
+    }
+}

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -170,8 +170,11 @@ extension ArtsyAPI : MoyaPath {
 
 extension ArtsyAPI : MoyaTarget {
     // TODO: - parameterize base URL based on debug, release, etc.
-     var baseURL: NSURL { return NSURL(string: "https://stagingapi.artsy.net")! }
-     var sampleData: NSData {
+
+    var base: String { return AppSetup.sharedState.useStaging ? "https://stagingapi.artsy.net" : "https://api.artsy.net" }
+    var baseURL: NSURL { return NSURL(string: base)! }
+
+    var sampleData: NSData {
         switch self {
 
         case XApp:
@@ -250,6 +253,7 @@ extension ArtsyAPI : MoyaTarget {
         
         var endpoint: Endpoint<ArtsyAPI> = Endpoint<ArtsyAPI>(URL: url(target), sampleResponse: .Success(200, target.sampleData), method: method, parameters: parameters)
         // Sign all non-XApp token requests
+
         switch target {
         case .XApp:
             return endpoint

--- a/Kiosk/Auction Listings/ListingsViewController.swift
+++ b/Kiosk/Auction Listings/ListingsViewController.swift
@@ -7,7 +7,7 @@ let TableCellIdentifier = "TableCell"
 
 class ListingsViewController: UIViewController {
     var allowAnimations = true
-    var auctionID = AuctionID
+    var auctionID = AppSetup.sharedState.auctionID
     
     dynamic var sale = Sale(id: "", isAuction: true, startDate: NSDate(), endDate: NSDate())
     dynamic var saleArtworks = [SaleArtwork]()

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
@@ -66,7 +66,12 @@ public class ConfirmYourBidArtsyLoginViewController: UIViewController {
     
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        emailTextField.becomeFirstResponder()
+        if countElements(emailTextField.text) == 0 {
+            emailTextField.becomeFirstResponder()
+        } else {
+            passwordTextField.becomeFirstResponder()
+        }
+
     }
 
     func xAuthSignal() -> RACSignal {

--- a/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
+++ b/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
@@ -14,10 +14,12 @@ public class SwipeCreditCardViewController: UIViewController, RegistrationSubCon
     dynamic var cardToken = ""
 
     lazy var keys = EidolonKeys()
-    lazy var cardHandler:CardHandler = CardHandler(apiKey: self.keys.cardflightAPIClientKey(), accountToken: self.keys.cardflightMerchantAccountToken())
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+
+        let merchantToken = AppSetup.sharedState.useStaging ? self.keys.cardflightMerchantAccountStagingToken() : self.keys.cardflightMerchantAccountToken()
+        let cardHandler = CardHandler(apiKey: self.keys.cardflightAPIClientKey(), accountToken:merchantToken)
 
         cardHandler.cardSwipedSignal.subscribeNext({ [unowned self] (message) -> Void in
             self.cardStatusLabel.text = "Card Status: \(message)"
@@ -28,7 +30,7 @@ public class SwipeCreditCardViewController: UIViewController, RegistrationSubCon
         }, completed: { [unowned self] () -> Void in
             self.cardStatusLabel.text = "Card Status: completed"
 
-            if let card = self.cardHandler.card {
+            if let card = cardHandler.card {
                 self.cardName = card.name
                 self.cardLastDigits = card.encryptedSwipedCardNumber
                 self.cardToken = card.cardToken

--- a/Kiosk/Storyboards/Auction.storyboard
+++ b/Kiosk/Storyboards/Auction.storyboard
@@ -83,7 +83,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z0Z-C8-aDL" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="783" y="20" width="176" height="44"/>
+                                <rect key="frame" x="783" y="20" width="176" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <state key="normal" title="REGISTER TO BID">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/Kiosk/Storyboards/Fulfillment.storyboard
+++ b/Kiosk/Storyboards/Fulfillment.storyboard
@@ -446,7 +446,6 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="confirmTapped:" destination="MRb-fW-vfZ" eventType="touchUpInside" id="OrA-IY-Yqg"/>
                                     <action selector="confirmTapped:" destination="BKe-0r-2Pc" eventType="touchUpInside" id="geK-LM-NHB"/>
                                 </connections>
                             </button>
@@ -685,7 +684,6 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="confirmTapped:" destination="MRb-fW-vfZ" eventType="touchUpInside" id="85q-hM-CSB"/>
                                     <action selector="createNewAccountTapped:" destination="MRb-fW-vfZ" eventType="touchUpInside" id="MQP-lO-coJ"/>
                                 </connections>
                             </button>
@@ -868,7 +866,6 @@
                                 <connections>
                                     <action selector="confirmButtonTapped:" destination="N1l-90-SiW" eventType="touchUpInside" id="ZV0-b8-KJQ"/>
                                     <action selector="confirmTapped:" destination="BKe-0r-2Pc" eventType="touchUpInside" id="vDO-RE-3Ba"/>
-                                    <action selector="confirmTapped:" destination="MRb-fW-vfZ" eventType="touchUpInside" id="w2s-T0-038"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -883,7 +880,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aFe-IW-rLA" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="602.5" y="1274"/>
+            <point key="canvasLocation" x="616.5" y="1698"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="yEo-PL-Kq3">
@@ -1219,7 +1216,7 @@
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="y4z-UB-ZdO" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
                                 <rect key="frame" x="65" y="237" width="319" height="44"/>
                                 <fontDescription key="fontDescription" name="AGaramondPro-Regular" family="Adobe Garamond Pro" pointSize="20"/>
-                                <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress"/>
                             </textField>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qef-T4-al0" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
                                 <rect key="frame" x="399" y="62" width="250" height="60"/>
@@ -1559,6 +1556,6 @@
     <inferredMetricsTieBreakers>
         <segue reference="TrF-tJ-vaM"/>
         <segue reference="NOJ-G3-crU"/>
-        <segue reference="qDL-1J-LmL"/>
+        <segue reference="6qF-R8-kJy"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
Moved to keep the our defaults in a single place. This could be thrown in the defaults for staging switches in admin etc at a later date.

Aside: I was surprised to find that the`let AuctionID = "ici-live-auction"` in `AppDelegate.swift` was being accessed from `ListingsViewController.swift` figured they'd be private by default.
