### PR TITLE
@orta => Fixed problem with overflowing labels on tabular cells.

### DIFF
--- a/Kiosk/ListingsCollectionViewCell.swift
+++ b/Kiosk/ListingsCollectionViewCell.swift
@@ -100,24 +100,28 @@ private extension MasonryCollectionViewCell {
     class func _rightAlignedNormalLabel() -> UILabel {
         let label = _normalLabel()
         label.textAlignment = .Right
+        label.numberOfLines = 1
         return label
     }
     
     class func _normalLabel() -> UILabel {
         let label = ARSerifLabel()
         label.font = label.font.fontWithSize(16)
+        label.numberOfLines = 1
         return label
     }
     
     class func _sansSerifLabel() -> UILabel {
         let label = ARSansSerifLabel()
         label.font = label.font.fontWithSize(14)
+        label.numberOfLines = 1
         return label
     }
     
     class func _italicsLabel() -> UILabel {
         let label = ARItalicsSerifLabel()
         label.font = label.font.fontWithSize(16)
+        label.numberOfLines = 1
         return label
     }
     
@@ -136,6 +140,7 @@ private extension MasonryCollectionViewCell {
     class func _boldLabel() -> UILabel {
         let label = _normalLabel()
         label.font = UIFont.serifBoldFontWithSize(label.font.pointSize)
+        label.numberOfLines = 1
         return label
     }
 }


### PR DESCRIPTION
![screen shot 2014-10-20 at 3 49 32 pm](https://cloud.githubusercontent.com/assets/498212/4702102/f08d7672-585f-11e4-9bca-907b780c0ecb.png)

Fixed in relation to #181.
