### PR TITLE
@orta => Fixes #181.

### DIFF
--- a/Kiosk/Auction Listings/MasonryCollectionViewCell.swift
+++ b/Kiosk/Auction Listings/MasonryCollectionViewCell.swift
@@ -46,6 +46,7 @@ class MasonryCollectionViewCell: ListingsCollectionViewCell {
         bidView.alignAttribute(.Top, toAttribute: .Bottom, ofView: dividerView, predicate: "13")
         bidView.constrainHeight("18")
         bidButton.alignAttribute(.Top, toAttribute: .Bottom, ofView: currentBidLabel, predicate: "13")
+        bidButton.alignAttribute(.Bottom, toAttribute: .Bottom, ofView: contentView, predicate: "40")
         
         // Bind subviews
         


### PR DESCRIPTION
Pretty simple fix. I think it has to do with our custom masonry layout combined with lack of height constraints on the content view (that is, we were just kind of letting the button's margin be defined by the extra space left over from `heightForSaleArtwork` instead of by a constrain). 
