### PR TITLE
@1aurabrown => Fixes #187.

### DIFF
--- a/Kiosk/Bid Fulfillment/PlacingBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/PlacingBidViewController.swift
@@ -95,6 +95,12 @@ class PlacingBidViewController: UIViewController {
         } else {
             isLowestBidder()
         }
+        
+        // Update the bid details sale artwork to our mostRecentSaleArtwork
+        if let mostRecentSaleArtwork = self.mostRecentSaleArtwork {
+            let bidDetails = self.fulfillmentNav().bidDetails
+            bidDetails.saleArtwork?.updateWithValues(mostRecentSaleArtwork)
+        }
 
         let showBidderDetails = hasCreatedAUser() || !foundHighestBidder
         if showBidderDetails {

--- a/Kiosk/Storyboards/Fulfillment.storyboard
+++ b/Kiosk/Storyboards/Fulfillment.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6249" systemVersion="14A388a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="O1R-5R-23t">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6249" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="O1R-5R-23t">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6243"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # End User Changes
 
+### Next
+
+* After placing a bid, the listings UI is immediately updated - @ash
+* UI fixes for tabular view – @ash
+
 ### 0.0.8 - 19th Oct 2014
 
 * Syncing updates to bids - @ash


### PR DESCRIPTION
Pretty straightforward – we have a most recent sale artwork, so if it's present, then update the current one (with a method that already exists thanks to sync). 
