### PR TITLE
@1aurabrown => Silly fix

### DIFF
--- a/Kiosk/App/AppDelegate+Help.swift
+++ b/Kiosk/App/AppDelegate+Help.swift
@@ -122,11 +122,11 @@ public extension AppDelegate {
 }
 
 extension AppDelegate: UIViewControllerTransitioningDelegate {
-    func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return HelpAnimator(presenting: true)
     }
     
-    func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return HelpAnimator()
     }
 }

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -3,7 +3,7 @@ import UIKit
 let log = XCGLogger.defaultInstance()
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+public class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var helpViewController: HelpViewController?
     var conditionsOfSaleViewController: UIViewController?


### PR DESCRIPTION
`UIBarButtonItem` needs a `public` method to call, since internal ones (the default) aren't accessible from UIKit. 
