### PR TITLE
@ashfurrow => ability to dismiss conditions/privacy

### DIFF
--- a/Kiosk/Admin/AdminPanelViewController.swift
+++ b/Kiosk/Admin/AdminPanelViewController.swift
@@ -20,12 +20,11 @@ class AdminPanelViewController: UIViewController {
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue == .LoadAdminWebViewController {
-            let webVC = segue.destinationViewController as WebViewController
+            let webVC = segue.destinationViewController as AuctionWebViewController
             let auctionID = AppSetup.sharedState.auctionID
             let base = AppSetup.sharedState.useStaging ? "staging.artsy.net" : "artsy.net"
 
             webVC.URL = NSURL(string: "https://\(base)/feature/\(auctionID)")!
-            webVC.showToolbar = true
 
             // TODO: Hide help button
         }

--- a/Kiosk/Admin/AuctionWebViewController.swift
+++ b/Kiosk/Admin/AuctionWebViewController.swift
@@ -15,7 +15,7 @@ class AuctionWebViewController: WebViewController {
         let allItems = self.toolbarItems! + [flexibleSpace, backwardBarItem] as [AnyObject]
         toolbarItems = allItems
     }
-    
+
     func exit() {
         let passwordVC = PasswordAlertViewController.alertView { [weak self] () -> () in
             self?.navigationController?.popViewControllerAnimated(true)

--- a/Kiosk/App/AppDelegate+GlobalActions.swift
+++ b/Kiosk/App/AppDelegate+GlobalActions.swift
@@ -35,14 +35,13 @@ public extension AppDelegate {
     
     func showWebControllerWithAddress(address: String) {
         let block = { () -> Void in
-            let webController = WebViewController(url: NSURL(string: address)!)
-            webController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: "cancelPresentedViewController")
+            let webController = ModalWebViewController(url: NSURL(string: address)!)
+
+            let nav = UINavigationController(rootViewController: webController)
+            nav!.modalPresentationStyle = .FormSheet
             
-            let webVC = UINavigationController(rootViewController: webController)
-            webVC!.modalPresentationStyle = .FormSheet
-            
-            self.window.rootViewController?.presentViewController(webVC!, animated: true, completion: nil)
-            self.webViewController = webVC
+            self.window.rootViewController?.presentViewController(nav!, animated: true, completion: nil)
+            self.webViewController = nav
         }
 
         if helpIsVisisble {
@@ -77,13 +76,8 @@ public extension AppDelegate {
         }
     }
 
-    public func cancelPresentedViewController() {
-        hidewebViewController()
-    }
-
     func hidewebViewController(completion: (() -> ())? = nil) {
         webViewController?.presentingViewController?.dismissViewControllerAnimated(true, completion: completion)
-        webViewController = nil
     }
 
     func setupHelpButton() {
@@ -151,8 +145,8 @@ public extension AppDelegate {
         setHelpButtonState(.Help)
 
         helpViewController?.presentingViewController?.dismissViewControllerAnimated(true) {
-            self.helpViewController = nil
             completion?()
+            return
         }
     }
 }

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -6,10 +6,10 @@ let log = XCGLogger.defaultInstance()
 @UIApplicationMain
 public class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var helpViewController: HelpViewController?
+    weak var helpViewController: HelpViewController?
     var helpButton: UIButton!
 
-    var webViewController: UIViewController?
+    weak var webViewController: UIViewController?
 
     var window: UIWindow! = UIWindow(frame:CGRectMake(0, 0, UIScreen.mainScreen().bounds.height, UIScreen.mainScreen().bounds.width))
 

--- a/Kiosk/Auction Listings/WebViewController.swift
+++ b/Kiosk/Auction Listings/WebViewController.swift
@@ -1,5 +1,7 @@
+let modalHeight: CGFloat = 660
+
 class WebViewController: DZNWebViewController {
-    var showToolbar = false
+    var showToolbar = true
 
     convenience init(url: NSURL) {
         self.init()
@@ -8,8 +10,6 @@ class WebViewController: DZNWebViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        preferredContentSize = CGSizeMake(815, 660)
-        navigationController?.view.layer.cornerRadius = 0;
 
         let webView = view as UIWebView
         webView.scalesPageToFit = true
@@ -19,13 +19,41 @@ class WebViewController: DZNWebViewController {
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        
-       self.navigationController?.setToolbarHidden(!showToolbar, animated: false)
+        navigationController?.setNavigationBarHidden(true, animated:false)
+        navigationController?.setToolbarHidden(!showToolbar, animated:false)
+    }
+}
+
+class ModalWebViewController: WebViewController {
+    var closeButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        closeButton = UIButton()
+        view.addSubview(closeButton)
+        closeButton.titleLabel?.font = UIFont.sansSerifFontWithSize(14)
+        closeButton.setTitleColor(UIColor.artsyMediumGrey(), forState:.Normal)
+        closeButton.setTitle("CLOSE", forState:.Normal)
+        closeButton.constrainWidth("140", height: "72")
+        closeButton.alignTop("0", leading:"0", bottom:nil, trailing:nil, toView:view)
+        closeButton.addTarget(self, action:"closeTapped:", forControlEvents:.TouchUpInside)
+
+        var height = modalHeight
+        if let nav = navigationController {
+            if !nav.navigationBarHidden { height -= CGRectGetHeight(nav.navigationBar.frame) }
+            if !nav.toolbarHidden { height -= CGRectGetHeight(nav.toolbar.frame) }
+        }
+        preferredContentSize = CGSizeMake(815, height)
     }
 
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
 
-        self.navigationController?.setToolbarHidden(!showToolbar, animated: false)
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.view.superview?.layer.cornerRadius = 0;
+    }
+
+    func closeTapped(sender: AnyObject) {
+        presentingViewController?.dismissViewControllerAnimated(true, completion:nil)
     }
 }

--- a/Kiosk/Storyboards/Auction.storyboard
+++ b/Kiosk/Storyboards/Auction.storyboard
@@ -181,7 +181,6 @@
         <scene sceneID="GeE-xH-04T">
             <objects>
                 <navigationController navigationBarHidden="YES" id="WE8-fs-xzH" sceneMemberID="viewController">
-                    <nil key="simulatedTopBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1Rz-le-5kW">
                         <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Kiosk/Storyboards/Fulfillment.storyboard
+++ b/Kiosk/Storyboards/Fulfillment.storyboard
@@ -107,7 +107,7 @@
                                 </connections>
                             </containerView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2zy-ga-dxf">
-                                <rect key="frame" x="105" y="54" width="107" height="52"/>
+                                <rect key="frame" x="105" y="54" width="140" height="72"/>
                                 <fontDescription key="fontDescription" name="ITCAvantGardeDemiTrack03" family="ITCAvantGardeDemiTrack03" pointSize="14"/>
                                 <state key="normal" title="CANCEL">
                                     <color key="titleColor" red="0.75686274509803919" green="0.75686274509803919" blue="0.75686274509803919" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
Made the modal for terms and conditions/privacy look a little more design-y

I put in the navigation toolbar on the bottom because there are links to other documents on each of the pages we're presenting. We can talk to Katarina about this. They're tappable either way, but it's frustrating if you tap on something and can't get back.

Added a CLOSE button to the modal that looks like the CANCEL button we display throughout bid fulfillment.
![modal](https://cloud.githubusercontent.com/assets/3171662/4728369/17660dac-5975-11e4-9671-fdcfc88bbd1b.gif)
