### PR TITLE
@ashfurrow => clean up divider lines in collection views

### DIFF
--- a/Kiosk/Auction Listings/MasonryCollectionViewCell.swift
+++ b/Kiosk/Auction Listings/MasonryCollectionViewCell.swift
@@ -5,18 +5,19 @@ let MasonryCollectionViewCellWidth: CGFloat = 254
 class MasonryCollectionViewCell: ListingsCollectionViewCell {
     private lazy var bidView: UIView = {
         let view = UIView()
-        view.addSubview(self.currentBidLabel)
-        view.addSubview(self.numberOfBidsLabel)
-
+        for subview in [self.currentBidLabel, self.numberOfBidsLabel] {
+            view.addSubview(subview)
+            subview.alignTopEdgeWithView(view, predicate:"13")
+            subview.alignBottomEdgeWithView(view, predicate:"0")
+            subview.constrainHeight("18")
+        }
         self.currentBidLabel.alignLeadingEdgeWithView(view, predicate: "0")
         self.numberOfBidsLabel.alignTrailingEdgeWithView(view, predicate: "0")
-        UIView.alignBottomEdgesOfViews([view, self.currentBidLabel, self.numberOfBidsLabel])
         return view
     }()
     
-    private lazy var cellSubviews: [UIView] = [self.artworkImageView, self.artistNameLabel, self.artworkTitleLabel, self.estimateLabel, self.dividerView, self.bidView, self.bidButton]
-    private lazy var cellWidthSubviews: [UIView] = [self.artworkImageView, self.artistNameLabel, self.artworkTitleLabel, self.estimateLabel, self.bidView, self.dividerView, self.bidButton]
-    
+    private lazy var cellSubviews: [UIView] = [self.artworkImageView, self.artistNameLabel, self.artworkTitleLabel, self.estimateLabel, self.bidView, self.bidButton]
+
     private var artworkImageViewHeightConstraint: NSLayoutConstraint?
     
     override func setup() {
@@ -24,16 +25,13 @@ class MasonryCollectionViewCell: ListingsCollectionViewCell {
         
         contentView.constrainWidth("\(MasonryCollectionViewCellWidth)")
         
-        // Configure subviews
-        // Need an explicit frame so that drawTopDottedBorder() is reliable
-        dividerView.frame = CGRect(origin: CGPointZero, size: CGSize(width: MasonryCollectionViewCellWidth, height: 1))
-        dividerView.drawTopDottedBorder()
-        
         // Add subviews
-        cellSubviews.map{ self.contentView.addSubview($0) }
+        for subview in cellSubviews {
+            self.contentView.addSubview(subview)
+            subview.alignLeading("0", trailing: "0", toView: self.contentView)
+        }
         
         // Constrain subviews
-        cellWidthSubviews.map { $0.alignLeading("0", trailing: "0", toView: self.contentView) }
         artworkImageView.alignTop("0", bottom: nil, toView: contentView)
         artistNameLabel.alignAttribute(.Top, toAttribute: .Bottom, ofView: artworkImageView, predicate: "20")
         artistNameLabel.constrainHeight("20")
@@ -41,10 +39,7 @@ class MasonryCollectionViewCell: ListingsCollectionViewCell {
         artworkTitleLabel.constrainHeight("16")
         estimateLabel.alignAttribute(.Top, toAttribute: .Bottom, ofView: artworkTitleLabel, predicate: "10")
         estimateLabel.constrainHeight("16")
-        dividerView.alignAttribute(.Top, toAttribute: .Bottom, ofView: estimateLabel, predicate: "13")
-        dividerView.constrainHeight("1")
-        bidView.alignAttribute(.Top, toAttribute: .Bottom, ofView: dividerView, predicate: "13")
-        bidView.constrainHeight("18")
+        bidView.alignAttribute(.Top, toAttribute: .Bottom, ofView: estimateLabel, predicate: "13")
         bidButton.alignAttribute(.Top, toAttribute: .Bottom, ofView: currentBidLabel, predicate: "13")
         bidButton.alignAttribute(.Bottom, toAttribute: .Bottom, ofView: contentView, predicate: "40")
         
@@ -61,6 +56,11 @@ class MasonryCollectionViewCell: ListingsCollectionViewCell {
             }
         }
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        bidView.drawTopDottedBorderWithColor(UIColor.artsyMediumGrey())
+    }
 }
 
 extension MasonryCollectionViewCell {
@@ -74,7 +74,6 @@ extension MasonryCollectionViewCell {
             10 + // padding
             16 + // estimate
             13 + // padding
-            1 +  // divider
             13 + // padding
             16 + // bid
             13 + // padding

--- a/Kiosk/Auction Listings/TableCollectionViewCell.swift
+++ b/Kiosk/Auction Listings/TableCollectionViewCell.swift
@@ -13,8 +13,8 @@ class TableCollectionViewCell: ListingsCollectionViewCell {
         self.artworkTitleLabel.alignTop(nil, bottom: "0", toView: view)
         return view
     }()
-    
-    private lazy var cellSubviews: [UIView] = [self.artworkImageView, self.infoView, self.dividerView, self.currentBidLabel, self.numberOfBidsLabel, self.bidButton]
+
+    private lazy var cellSubviews: [UIView] = [self.artworkImageView, self.infoView, self.currentBidLabel, self.numberOfBidsLabel, self.bidButton]
     
     override func setup() {
         super.setup()
@@ -46,8 +46,11 @@ class TableCollectionViewCell: ListingsCollectionViewCell {
         bidButton.alignBottom(nil, trailing: "0", toView: contentView)
         bidButton.alignCenterYWithView(artworkImageView, predicate: "0")
         bidButton.constrainWidth("127")
-        dividerView.constrainHeight("1")
-        dividerView.alignTop(nil, leading: "0", bottom: "0", trailing: "0", toView: contentView)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.drawBottomSolidBorderWithColor(UIColor.artsyMediumGrey())
     }
 }
 

--- a/Kiosk/ListingsCollectionViewCell.swift
+++ b/Kiosk/ListingsCollectionViewCell.swift
@@ -1,14 +1,13 @@
 import Foundation
 
 class ListingsCollectionViewCell: UICollectionViewCell {
-    dynamic let artworkImageView = MasonryCollectionViewCell._artworkImageView()
-    dynamic let artistNameLabel = MasonryCollectionViewCell._largeLabel()
-    dynamic let artworkTitleLabel = MasonryCollectionViewCell._italicsLabel()
-    dynamic let estimateLabel = MasonryCollectionViewCell._normalLabel()
-    dynamic let dividerView: UIView = MasonryCollectionViewCell._dividerView()
-    dynamic let currentBidLabel = MasonryCollectionViewCell._boldLabel()
-    dynamic let numberOfBidsLabel = MasonryCollectionViewCell._rightAlignedNormalLabel()
-    dynamic let bidButton = MasonryCollectionViewCell._bidButton()
+    dynamic let artworkImageView = ListingsCollectionViewCell._artworkImageView()
+    dynamic let artistNameLabel = ListingsCollectionViewCell._largeLabel()
+    dynamic let artworkTitleLabel = ListingsCollectionViewCell._italicsLabel()
+    dynamic let estimateLabel = ListingsCollectionViewCell._normalLabel()
+    dynamic let currentBidLabel = ListingsCollectionViewCell._boldLabel()
+    dynamic let numberOfBidsLabel = ListingsCollectionViewCell._rightAlignedNormalLabel()
+    dynamic let bidButton = ListingsCollectionViewCell._bidButton()
     
     dynamic var saleArtwork: SaleArtwork?
     dynamic var bidWasPressedSignal: RACSignal = RACSubject()
@@ -82,7 +81,7 @@ class ListingsCollectionViewCell: UICollectionViewCell {
     }
 }
 
-private extension MasonryCollectionViewCell {
+private extension ListingsCollectionViewCell {
     
     // Mark: UIView-property-methods – need an _ prefix to appease the compiler ¯\_(ツ)_/¯
     class func _artworkImageView() -> UIImageView {
@@ -90,13 +89,7 @@ private extension MasonryCollectionViewCell {
         imageView.backgroundColor = UIColor.artsyLightGrey()
         return imageView
     }
-    
-    class func _dividerView() -> UIView {
-        let dividerView = UIView()
-        dividerView.backgroundColor = UIColor.artsyMediumGrey()
-        return dividerView
-    }
-    
+
     class func _rightAlignedNormalLabel() -> UILabel {
         let label = _normalLabel()
         label.textAlignment = .Right

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ inhibit_all_warnings!
 # Artsy stuff
 pod 'Artsy+UIColors'
 pod 'Artsy+UILabels'
-pod 'Artsy-UIButtons', :git => 'https://github.com/artsy/Artsy-UIButtons.git', :commit => 'a28bc016f25fc184da4dad49d11c7774afda85ce'
+pod 'Artsy-UIButtons'
 
 # We'll need to include travis some time.
 if ENV['USER'] == "orta" || ENV['USER'] == "ash" || ENV['USER'] == "artsy" || ENV['USER'] == "Laura"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,13 +10,13 @@ PODS:
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - Artsy+UIFonts (1.0.0)
-  - Artsy+UILabels (1.3.0):
+  - Artsy+UILabels (1.3.1):
     - Artsy+UIColors
-  - Artsy-UIButtons (1.1.0):
+  - Artsy-UIButtons (1.2.0):
     - Artsy+UIColors
-  - CardFlight (1.8):
+  - CardFlight (1.8.3):
     - CardFlight/AudioJack
-  - CardFlight/AudioJack (1.8)
+  - CardFlight/AudioJack (1.8.3)
   - DZNWebViewController (2.0):
     - NJKWebViewProgress (~> 0.2)
   - ECPhoneNumberFormatter (0.1.1)
@@ -45,7 +45,7 @@ DEPENDENCIES:
   - Artsy+UIColors
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`, branch `new-tracking`)
   - Artsy+UILabels
-  - Artsy-UIButtons (from `https://github.com/artsy/Artsy-UIButtons.git`, commit `a28bc016f25fc184da4dad49d11c7774afda85ce`)
+  - Artsy-UIButtons
   - CardFlight
   - DZNWebViewController (from `https://github.com/orta/DZNWebViewController.git`)
   - ECPhoneNumberFormatter
@@ -61,9 +61,6 @@ EXTERNAL SOURCES:
   Artsy+UIFonts:
     :branch: new-tracking
     :git: https://github.com/artsy/Artsy-UIFonts.git
-  Artsy-UIButtons:
-    :commit: a28bc016f25fc184da4dad49d11c7774afda85ce
-    :git: https://github.com/artsy/Artsy-UIButtons.git
   DZNWebViewController:
     :git: https://github.com/orta/DZNWebViewController.git
   FBSnapshotTestCase:
@@ -77,9 +74,9 @@ SPEC CHECKSUMS:
   ARCollectionViewMasonryLayout: 40993cb65522139cb2cd6ed255c91a6caee5c4dd
   Artsy+UIColors: d1d5e084a0e542d310c507acb5446bae6a322241
   Artsy+UIFonts: fb0a70f93ca888d45a3af751707701fe8cbeae2a
-  Artsy+UILabels: 1dfc53c1e79727664c6081e305aeefa557ac5de5
-  Artsy-UIButtons: af5cf4179dc7022d630c768d17c42eb5c1688319
-  CardFlight: 22298dc11252ce13160073c416506c869abea9a1
+  Artsy+UILabels: a7c713069e3d10144a3dc8e377bef8b2253cd766
+  Artsy-UIButtons: 80a957b9479417c3be1e68d5b830de6cd2ec44cc
+  CardFlight: 6efbffb69e4ab27629ac0fe18e04790ac6c7d53b
   DZNWebViewController: 8716115ea00d6abbfb5dc937fff85b222b70fc68
   ECPhoneNumberFormatter: 5e178027d1d43472187c3f623e7b69b89fdb3187
   EDColor: bcdb8600b7a456f4408ce1d7e7fc001588919254


### PR DESCRIPTION
Instead of using a 1-px view for our dotted and solid borders/dividers, let's just use the ARDrawing methods we have in the UILabels pod to draw a border layer on whatever view requires a border.

We were sort of doing this in the place where we were supposed to be using a dotted border, but we were basically adding a dotted border to a 1px UIView that was already serving as a solid border. This gets rid of all those single pixel divider views.

The table views looks the same as before with this change:
![screen shot 2014-10-22 at 1 31 35 pm](https://cloud.githubusercontent.com/assets/3171662/4740913/afc431ea-5a11-11e4-9bef-9266a28b68c6.png)

And the dotted divider actually looks right now:
![screen shot 2014-10-22 at 1 31 47 pm](https://cloud.githubusercontent.com/assets/3171662/4740920/c66d7ffa-5a11-11e4-9958-f089227a1bfb.png)
