### PR TITLE
@ashfurrow => Card handling fixes

### DIFF
--- a/Kiosk/Admin/AdminCardTestingViewController.swift
+++ b/Kiosk/Admin/AdminCardTestingViewController.swift
@@ -3,6 +3,7 @@ import Foundation
 class AdminCardTestingViewController: UIViewController {
 
     lazy var keys = EidolonKeys()
+    var cardHandler: CardHandler!
 
     @IBOutlet weak var logTextView: UITextView!
 
@@ -13,7 +14,7 @@ class AdminCardTestingViewController: UIViewController {
         self.logTextView.text = ""
 
         let merchantToken = AppSetup.sharedState.useStaging ? self.keys.cardflightMerchantAccountStagingToken() : self.keys.cardflightMerchantAccountToken()
-        let cardHandler = CardHandler(apiKey: self.keys.cardflightAPIClientKey(), accountToken:merchantToken)
+        cardHandler = CardHandler(apiKey: self.keys.cardflightAPIClientKey(), accountToken:merchantToken)
         
         cardHandler.cardSwipedSignal.subscribeNext({ (message) -> Void in
                 self.log("\(message)")
@@ -22,22 +23,27 @@ class AdminCardTestingViewController: UIViewController {
             }, error: { (error) -> Void in
 
                 self.log("\n====Error====\n\(error)\n\n")
-                if cardHandler.card != nil {
-                    self.log("==\n\(cardHandler.card!)\n\n")
+                if self.cardHandler.card != nil {
+                    self.log("==\n\(self.cardHandler.card!)\n\n")
                 }
 
 
             }, completed: {
 
-                if let card = cardHandler.card {
+                if let card = self.cardHandler.card {
                     let cardDetails = "Card: \(card.name) - \(card.encryptedSwipedCardNumber) \n \(card.cardToken)"
                     self.log(cardDetails)
                 }
 
-                cardHandler.startSearching()
+                self.cardHandler.startSearching()
         })
 
         cardHandler.startSearching()
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        cardHandler.end()
     }
 
     func log(string: String) {

--- a/Kiosk/App/CardHandler.swift
+++ b/Kiosk/App/CardHandler.swift
@@ -8,19 +8,22 @@ class CardHandler: NSObject, CFTReaderDelegate {
     let APIKey: String
     let APIToken: String
 
-    lazy var reader = CFTReader(andConnect: ())
+    var reader: CFTReader!
     lazy var sessionManager = CFTSessionManager.sharedInstance()
 
     init(apiKey: String, accountToken: String){
         APIKey = apiKey
         APIToken = accountToken
+
         super.init()
+
+        sessionManager.setApiToken(APIKey, accountToken: APIToken)
     }
 
     func startSearching() {
-        sessionManager.setApiToken(APIKey, accountToken: APIToken)
         sessionManager.setLogging(true)
-        
+
+        reader = CFTReader(andConnect: ())
         reader.delegate = self;
         reader.swipeTimeoutDuration(0)
         cardSwipedSignal.sendNext("Started searching");
@@ -28,6 +31,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
 
     func end() {
         reader.cancelSwipeWithMessage(nil)
+        reader = nil
     }
 
     func readerCardResponse(card: CFTCard?, withError error: NSError?) {
@@ -41,7 +45,6 @@ class CardHandler: NSObject, CFTReaderDelegate {
 
 
             }, failure: { (error) -> Void in
-                println("Error: \(error) ")
                 self.cardSwipedSignal.sendNext("Card Flight Error: \(error)");
                 logger.error("Card was not tokenizable")
             })

--- a/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
+++ b/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
@@ -39,6 +39,7 @@ public class SwipeCreditCardViewController: UIViewController, RegistrationSubCon
                 self.processingLabel.text = "ERROR PROCESSING CARD - SEE ADMIN"
             }
 
+
         }, error: { (error) -> Void in
             self.cardStatusLabel.text = "Card Status: Errored"
             self.setInProgress(false)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # End User Changes
 
-### 2.1.0 5th Nov 2014
+### 2.1.0 10th Nov 2014
 
 * Improved manual input handling - @orta
 * Fixed messages at the end of registration flow - @orta


### PR DESCRIPTION
You can only have one reader instance in memory at any time, so we have to be significantly more aggressive about `nil`ing existing instances.

Fixes #300 

![Giphy](http://media4.giphy.com/media/MbMHnivVvsNr2/giphy.gif)
