### PR TITLE
Fix memory leak in getSSID

### DIFF
--- a/Kiosk/Auction Listings/ListingsViewController.swift
+++ b/Kiosk/Auction Listings/ListingsViewController.swift
@@ -144,14 +144,14 @@ public class ListingsViewController: UIViewController {
     
     // Adapted from https://github.com/FUKUZAWA-Tadashi/FHCCommander/blob/67c67757ee418a106e0ce0c0820459299b3d77bb/fhcc/Convenience.swift#L33-L44
     func getSSID() -> String? {
-        let interfaces: CFArray! = CNCopySupportedInterfaces()?.takeUnretainedValue()
+        let interfaces: CFArray! = CNCopySupportedInterfaces()?.takeRetainedValue()
         if interfaces == nil { return nil }
         
         let if0: UnsafePointer<Void>? = CFArrayGetValueAtIndex(interfaces, 0)
         if if0 == nil { return nil }
         
         let interfaceName: CFStringRef = unsafeBitCast(if0!, CFStringRef.self)
-        let dictionary = CNCopyCurrentNetworkInfo(interfaceName)?.takeUnretainedValue() as NSDictionary?
+        let dictionary = CNCopyCurrentNetworkInfo(interfaceName)?.takeRetainedValue() as NSDictionary?
         if dictionary == nil { return nil }
         
         return dictionary?[kCNNetworkInfoKeySSID as String] as? String


### PR DESCRIPTION
You own the return values of both `CNCopySupportedInterfaces()` and `CNCopyCurrentNetworkInfo()` -- calling `takeUnretainedValue()` on the result doesn't relinquish ownership. Instead, use `takeRetainedValue()`, which releases the unmanaged result while converting it to a memory-managed Swift type.
