### PR TITLE
@1aurabrown => Deprecates old style of instantiating view controllers in tests. 

### DIFF
--- a/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
@@ -14,10 +14,8 @@ public class ConfirmYourBidArtsyLoginViewController: UIViewController {
     var createNewAccount = false
     lazy var provider:ReactiveMoyaProvider<ArtsyAPI> = Provider.sharedProvider
 
-    public class func instantiateFromStoryboard() -> ConfirmYourBidArtsyLoginViewController {
-        let a = UIStoryboard.fulfillment().viewControllerWithID(.ConfirmYourBidArtsyLogin)
-        println(a.navigationController)
-        return a as ConfirmYourBidArtsyLoginViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> ConfirmYourBidArtsyLoginViewController {
+        return storyboard.viewControllerWithID(.ConfirmYourBidArtsyLogin) as ConfirmYourBidArtsyLoginViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
@@ -7,8 +7,9 @@ public class ConfirmYourBidEnterYourEmailViewController: UIViewController {
     @IBOutlet public var emailTextField: UITextField!
     @IBOutlet public var confirmButton: UIButton!
     @IBOutlet public var bidDetailsPreviewView: BidDetailsPreviewView!
-    public class func instantiateFromStoryboard() -> ConfirmYourBidEnterYourEmailViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.ConfirmYourBidEnterEmail) as ConfirmYourBidEnterYourEmailViewController
+
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> ConfirmYourBidEnterYourEmailViewController {
+        return storyboard.viewControllerWithID(.ConfirmYourBidEnterEmail) as ConfirmYourBidEnterYourEmailViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -17,8 +17,8 @@ public class ConfirmYourBidPINViewController: UIViewController {
     public lazy var deleteSignal: RACSignal! = self.keypadContainer.keypad?.leftSignal
     public lazy var provider: ReactiveMoyaProvider<ArtsyAPI> = Provider.sharedProvider
 
-    public class func instantiateFromStoryboard() -> ConfirmYourBidPINViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.ConfirmYourBidPIN) as ConfirmYourBidPINViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> ConfirmYourBidPINViewController {
+        return storyboard.viewControllerWithID(.ConfirmYourBidPIN) as ConfirmYourBidPINViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPasswordViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPasswordViewController.swift
@@ -6,8 +6,8 @@ public class ConfirmYourBidPasswordViewController: UIViewController {
 
     @IBOutlet var bidDetailsPreviewView: BidDetailsPreviewView!
 
-    class func instantiateFromStoryboard() -> ConfirmYourBidEnterYourEmailViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.ConfirmYourBid) as ConfirmYourBidEnterYourEmailViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> ConfirmYourBidPasswordViewController {
+        return storyboard.viewControllerWithID(.ConfirmYourBid) as ConfirmYourBidPasswordViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidViewController.swift
@@ -21,8 +21,8 @@ public class ConfirmYourBidViewController: UIViewController {
     public lazy var deleteSignal:RACSignal! = self.keypadContainer.keypad?.leftSignal
     public lazy var provider:ReactiveMoyaProvider<ArtsyAPI> = Provider.sharedProvider
 
-    public class func instantiateFromStoryboard() -> ConfirmYourBidViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.ConfirmYourBid) as ConfirmYourBidViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> ConfirmYourBidViewController {
+        return storyboard.viewControllerWithID(.ConfirmYourBid) as ConfirmYourBidViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/FulfillmentContainerViewController.swift
+++ b/Kiosk/Bid Fulfillment/FulfillmentContainerViewController.swift
@@ -58,9 +58,7 @@ public class FulfillmentContainerViewController: UIViewController {
         return self.childViewControllers.first as? FulfillmentNavigationController
     }
 
-    class func instantiateFromStoryboard() -> FulfillmentContainerViewController {
-        return  UIStoryboard(name: "Fulfillment", bundle: nil)
-            .instantiateViewControllerWithIdentifier(ViewControllerStoryboardIdentifier.FulfillmentContainer.rawValue) as FulfillmentContainerViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> FulfillmentContainerViewController {
+        return storyboard.viewControllerWithID(.FulfillmentContainer) as FulfillmentContainerViewController
     }
-    
 }

--- a/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/PlaceBidViewController.swift
@@ -31,8 +31,8 @@ public class PlaceBidViewController: UIViewController {
     lazy public var clearSignal: RACSignal!  = self.keypadContainer.keypad?.rightSignal
     lazy public var deleteSignal: RACSignal! = self.keypadContainer.keypad?.leftSignal
 
-    public class func instantiateFromStoryboard() -> PlaceBidViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.PlaceYourBid) as PlaceBidViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> PlaceBidViewController {
+        return storyboard.viewControllerWithID(.PlaceYourBid) as PlaceBidViewController
     }
 
     override public func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/RegisterViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegisterViewController.swift
@@ -20,8 +20,8 @@ class RegisterViewController: UIViewController {
 
     dynamic var placingBid = true
 
-    class func instantiateFromStoryboard() -> RegisterViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.RegisterAnAccount) as RegisterViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> RegisterViewController {
+        return storyboard.viewControllerWithID(.RegisterAnAccount) as RegisterViewController
     }
 
     func internalNavController() -> UINavigationController? {

--- a/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
+++ b/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
@@ -14,8 +14,8 @@ public class SwipeCreditCardViewController: UIViewController, RegistrationSubCon
 
     @IBOutlet weak var titleLabel: ARSerifLabel!
 
-    public class func instantiateFromStoryboard() -> SwipeCreditCardViewController {
-        return UIStoryboard.fulfillment().viewControllerWithID(.RegisterCreditCard) as SwipeCreditCardViewController
+    class public func instantiateFromStoryboard(storyboard: UIStoryboard) -> SwipeCreditCardViewController {
+        return storyboard.viewControllerWithID(.RegisterCreditCard) as SwipeCreditCardViewController
     }
 
     dynamic var cardName = ""

--- a/KioskTests/Bid Fulfillment/ConfirmYourBidArtsyLoginViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/ConfirmYourBidArtsyLoginViewControllerTests.swift
@@ -7,7 +7,7 @@ class ConfirmYourBidArtsyLoginViewControllerTests: QuickSpec {
     override func spec() {
 
         it("looks right by default") {
-            let sut = ConfirmYourBidArtsyLoginViewController.instantiateFromStoryboard().wrapInFulfillmentNav()
+            let sut = ConfirmYourBidArtsyLoginViewController.instantiateFromStoryboard(fulfillmentStoryboard).wrapInFulfillmentNav()
             expect(sut).to(haveValidSnapshot())
         }
 

--- a/KioskTests/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewControllerTests.swift
@@ -3,16 +3,20 @@ import Nimble
 import Kiosk
 import Nimble_Snapshots
 
+func testConfirmYourBidEnterYourEmailViewController() -> ConfirmYourBidEnterYourEmailViewController {
+    return ConfirmYourBidEnterYourEmailViewController.instantiateFromStoryboard(fulfillmentStoryboard).wrapInFulfillmentNav() as ConfirmYourBidEnterYourEmailViewController
+}
+
 class ConfirmYourBidEnterYourEmailViewControllerTests: QuickSpec {
     override func spec() {
 
         it("looks right by default") {
-            let sut = ConfirmYourBidEnterYourEmailViewController.instantiateFromStoryboard().wrapInFulfillmentNav()
+            let sut = testConfirmYourBidEnterYourEmailViewController()
             expect(sut).to(haveValidSnapshot())
         }
 
         it("passes the email to the nav's bid details object") {
-            let sut = ConfirmYourBidEnterYourEmailViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidEnterYourEmailViewController
+            let sut = testConfirmYourBidEnterYourEmailViewController()
             let nav = sut.navigationController as FulfillmentNavigationController
             sut.loadViewProgrammatically()
 
@@ -23,7 +27,7 @@ class ConfirmYourBidEnterYourEmailViewControllerTests: QuickSpec {
         }
 
         it("confirm button is disabled when no email") {
-            let sut = ConfirmYourBidEnterYourEmailViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidEnterYourEmailViewController
+            let sut = testConfirmYourBidEnterYourEmailViewController()
             let nav = FulfillmentNavigationController(rootViewController:sut)
             nav.loadViewProgrammatically()
             sut.loadViewProgrammatically()
@@ -32,7 +36,7 @@ class ConfirmYourBidEnterYourEmailViewControllerTests: QuickSpec {
         }
 
         pending("enables the enter button when an email + password is entered") {
-            let sut = ConfirmYourBidEnterYourEmailViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidEnterYourEmailViewController
+            let sut = testConfirmYourBidEnterYourEmailViewController()
             let nav = sut.navigationController as FulfillmentNavigationController
             sut.loadViewProgrammatically()
 

--- a/KioskTests/Bid Fulfillment/ConfirmYourBidPINViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/ConfirmYourBidPINViewControllerTests.swift
@@ -9,13 +9,13 @@ class ConfirmYourBidPINViewControllerTests: QuickSpec {
     override func spec() {
 
         it("looks right by default") {
-            let sut = ConfirmYourBidPINViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidPINViewController
+            let sut = testConfirmYourBidPINViewController()
             expect(sut).to(haveValidSnapshot())
         }
 
         it("reacts to keypad inputs with the string") {
             let customKeySubject = RACSubject()
-            let sut = ConfirmYourBidPINViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidPINViewController
+            let sut = testConfirmYourBidPINViewController()
             sut.keypadSignal = customKeySubject;
             sut.loadViewProgrammatically()
 
@@ -34,7 +34,7 @@ class ConfirmYourBidPINViewControllerTests: QuickSpec {
             let customKeySubject = RACSubject()
             let deleteSubject = RACSubject()
 
-            let sut = ConfirmYourBidPINViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidPINViewController
+            let sut = testConfirmYourBidPINViewController()
             sut.keypadSignal = customKeySubject;
             sut.deleteSignal = deleteSubject
 
@@ -51,7 +51,7 @@ class ConfirmYourBidPINViewControllerTests: QuickSpec {
             let customKeySubject = RACSubject()
             let clearSubject = RACSubject()
 
-            let sut = ConfirmYourBidPINViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidPINViewController
+            let sut = testConfirmYourBidPINViewController()
             sut.keypadSignal = customKeySubject;
             sut.clearSignal = clearSubject
 
@@ -86,4 +86,8 @@ class ConfirmYourBidPINViewControllerTests: QuickSpec {
         }
 
     }
+}
+
+func testConfirmYourBidPINViewController() -> ConfirmYourBidPINViewController {
+    return ConfirmYourBidPINViewController.instantiateFromStoryboard(fulfillmentStoryboard).wrapInFulfillmentNav() as ConfirmYourBidPINViewController
 }

--- a/KioskTests/Bid Fulfillment/ConfirmYourBidViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/ConfirmYourBidViewControllerTests.swift
@@ -10,7 +10,7 @@ class ConfirmYourBidViewControllerTests: QuickSpec {
         var nav: FulfillmentNavigationController!
 
         beforeEach {
-            sut = ConfirmYourBidViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as ConfirmYourBidViewController
+            sut = ConfirmYourBidViewController.instantiateFromStoryboard(fulfillmentStoryboard).wrapInFulfillmentNav() as ConfirmYourBidViewController
             nav = FulfillmentNavigationController(rootViewController:sut)
         }
 

--- a/KioskTests/Bid Fulfillment/FulfillmentContainerViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/FulfillmentContainerViewControllerTests.swift
@@ -4,18 +4,7 @@ import Nimble
 class FulfillmentContainerViewControllerTests: QuickSpec {
     override func spec() {
         
-        it("dismisses itself when closeModalTapped is called") {
-//            let window = UIApplication.sharedApplication().delegate!.window!
-//            let host = UIViewController()
-//            let sut = FulfillmentContainerViewController.instantiateFromStoryboard()
-//            
-//            window!.rootViewController = host
-//            host.presentViewController(sut, animated: false, completion: nil)
-//            
-//            sut.allowAnimations = false;
-//            sut.closeModalTapped("")
-//            
-//            expect(sut.isBeingPresented()).to(beNil())
+        pending("dismisses itself when closeModalTapped is called") {
         }
 
     }

--- a/KioskTests/Bid Fulfillment/PlaceBidViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/PlaceBidViewControllerTests.swift
@@ -14,7 +14,7 @@ class PlaceBidViewControllerTests: QuickSpec {
         ]
 
         beforeEach {
-            sut = PlaceBidViewController.instantiateFromStoryboard().wrapInFulfillmentNav() as PlaceBidViewController
+            sut = PlaceBidViewController.instantiateFromStoryboard(fulfillmentStoryboard).wrapInFulfillmentNav() as PlaceBidViewController
         }
 
         pending("looks right by default") {

--- a/KioskTests/KioskTests.swift
+++ b/KioskTests/KioskTests.swift
@@ -12,3 +12,6 @@ extension UIViewController {
         return self
     }
 }
+
+let auctionStoryboard = UIStoryboard.auction()
+let fulfillmentStoryboard = UIStoryboard.fulfillment()

--- a/KioskTests/ListingsViewControllerTests.swift
+++ b/KioskTests/ListingsViewControllerTests.swift
@@ -9,8 +9,6 @@ import Moya
 class ListingsViewControllerTests: QuickSpec {
     let imageCache = SDImageCache.sharedImageCache()
     override func spec() {
-        let storyboard = UIStoryboard.auction()
-
         beforeEach {
             Provider.sharedProvider = Provider.StubbingProvider()
             
@@ -34,7 +32,7 @@ class ListingsViewControllerTests: QuickSpec {
         describe("when displaying stubbed contents.") {
             var sut: ListingsViewController!
             beforeEach {
-                sut = testListingsViewController(storyboard)
+                sut = testListingsViewController()
                 sut.loadViewProgrammatically()
             }
 
@@ -97,7 +95,7 @@ class ListingsViewControllerTests: QuickSpec {
             }
             
             pending("paginates to the second page to retrieve all three sale artworks") {
-                let sut = testListingsViewController(storyboard)
+                let sut = testListingsViewController()
                 sut.pageSize = 2
                 
                 sut.beginAppearanceTransition(true, animated: false)
@@ -108,7 +106,7 @@ class ListingsViewControllerTests: QuickSpec {
             }
             
             pending("updates with new values in existing sale artworks") {
-                let sut = testListingsViewController(storyboard)
+                let sut = testListingsViewController()
                 sut.syncInterval = 1
                 
                 sut.beginAppearanceTransition(true, animated: false)
@@ -122,7 +120,7 @@ class ListingsViewControllerTests: QuickSpec {
             }
             
             pending("updates with new sale artworks when lengths differ") {
-                let sut = testListingsViewController(storyboard)
+                let sut = testListingsViewController()
                 sut.syncInterval = 1
                 
                 sut.beginAppearanceTransition(true, animated: false)
@@ -143,7 +141,7 @@ let testSchedule = { (signal: RACSignal, scheduler: RACScheduler) -> RACSignal i
     return signal
 }
 
-func testListingsViewController(storyboard: UIStoryboard) -> ListingsViewController {
+func testListingsViewController(storyboard: UIStoryboard = auctionStoryboard) -> ListingsViewController {
     let sut = ListingsViewController.instantiateFromStoryboard(storyboard)
     sut.schedule = testSchedule
     sut.auctionID = ""


### PR DESCRIPTION
@orta I decided to just use one test suite-white storyboard that we use to instantiate view controllers. 