### PR TITLE
[Exploration] Build before test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 	xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration '$(CONFIGURATION)' clean
 
 test:
-	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug test -sdk iphonesimulator -destination $(DEVICE_HOST) | xcpretty --test
+	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug build test -sdk iphonesimulator -destination $(DEVICE_HOST) | xcpretty --test
 
 ipa:
 	$(PLIST_BUDDY) -c "Set CFBundleDisplayName $(BUNDLE_NAME)" $(APP_PLIST)


### PR DESCRIPTION
I found out that in the xcodebuild commands it is required to have `build test` instead of `test` for Xcode to launch the simulator.
Otherwise, if your build is taking longer than 2 minutes, it aborts because of the timeout.
As I saw in your Makefile your are just calling `test` so that might fix the problem described in https://github.com/artsy/eidolon/pull/379#issuecomment-74949058?