### PR TITLE
@orta => Bidder Details Notification

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -1264,10 +1264,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "$(SRCROOT)/Kiosk/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kiosk/Supporting Files/BridgingHeader.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1284,6 +1286,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Kiosk/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kiosk/Supporting Files/BridgingHeader.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};

--- a/Kiosk/App/AppDelegate+GlobalActions.swift
+++ b/Kiosk/App/AppDelegate+GlobalActions.swift
@@ -79,7 +79,7 @@ extension AppDelegate {
             RACSignal.empty().then {
                 self.hideHelpSignal()
             }.then {
-                self.showBidderDetailsRetrievealSignal()
+                self.showBidderDetailsRetrievalSignal()
             }
         }
     }
@@ -121,7 +121,7 @@ private extension AppDelegate {
         }
     }
     
-    func showBidderDetailsRetrievealSignal() -> RACSignal {
+    func showBidderDetailsRetrievalSignal() -> RACSignal {
         let appVC = self.appViewController
         let presentingViewController: UIViewController = (appVC.presentedViewController ?? appVC)
         return presentingViewController.promptForBidderDetailsRetrievalSignal()

--- a/Kiosk/App/AppDelegate+GlobalActions.swift
+++ b/Kiosk/App/AppDelegate+GlobalActions.swift
@@ -79,15 +79,7 @@ extension AppDelegate {
             RACSignal.empty().then {
                 self.hideHelpSignal()
             }.then {
-                return RACSignal.createSignal { _ -> RACDisposable! in
-                    let appVC = self.appViewController
-                    if let presentingVIewController = appVC?.presentedViewController ?? appVC {
-                        // TODO: This should be a signal and stuff
-                        presentingVIewController.promptForBidderDetailsRetrieval()
-                    }
-
-                    return nil
-                }
+                self.showBidderDetailsRetrievealSignal()
             }
         }
     }
@@ -127,6 +119,12 @@ private extension AppDelegate {
         }.then {
             self.hideHelpSignal()
         }
+    }
+    
+    func showBidderDetailsRetrievealSignal() -> RACSignal {
+        let appVC = self.appViewController
+        let presentingViewController: UIViewController = (appVC.presentedViewController ?? appVC)
+        return presentingViewController.promptForBidderDetailsRetrievalSignal()
     }
 
     func showRegistrationSignal() -> RACSignal {

--- a/Kiosk/App/BidderDetailsRetrieval.swift
+++ b/Kiosk/App/BidderDetailsRetrieval.swift
@@ -6,10 +6,10 @@ import SVProgressHUD
 public extension UIViewController {
     func promptForBidderDetailsRetrievalSignal() -> RACSignal {
         return RACSignal.createSignal { (subscriber) -> RACDisposable! in
-            let (alertControler, command) = UIAlertController.emailPromptAlertController()
+            let (alertController, command) = UIAlertController.emailPromptAlertController()
             
             subscriber.sendNext(command.executionSignals.switchToLatest())
-            self.presentViewController(alertControler, animated: true) { }
+            self.presentViewController(alertController, animated: true) { }
             
             return nil
         }.map { (emailSignal) -> AnyObject! in

--- a/Kiosk/App/BidderDetailsRetrieval.swift
+++ b/Kiosk/App/BidderDetailsRetrieval.swift
@@ -47,7 +47,7 @@ extension UIAlertController {
         alertController.addAction(RACAlertAction(title: "Cancel", style: .Cancel))
         
         let retryAction = RACAlertAction(title: "Retry", style: .Default)
-        retryAction.rac_command = appDelegate().requestBidderDetailsCommand()
+        retryAction.command = appDelegate().requestBidderDetailsCommand()
         
         alertController.addAction(retryAction)
         
@@ -58,7 +58,7 @@ extension UIAlertController {
         let alertController = self(title: "Send Bidder Details", message: "Enter your email address registered with Artsy and we will send your bidder number and PIN.", preferredStyle: .Alert)
 
         let ok = RACAlertAction(title: "OK", style: .Default)
-        ok.rac_command = RACCommand { (_) -> RACSignal! in
+        ok.command = RACCommand { (_) -> RACSignal! in
             
             return RACSignal.createSignal { (subscriber) -> RACDisposable! in
                 let text = (alertController.textFields?.first as? UITextField)?.text ?? ""
@@ -72,6 +72,6 @@ extension UIAlertController {
         alertController.addAction(ok)
         alertController.addAction(cancel)
 
-        return (alertController, ok.rac_command)
+        return (alertController, ok.command)
     }
 }

--- a/Kiosk/App/BidderDetailsRetrieval.swift
+++ b/Kiosk/App/BidderDetailsRetrieval.swift
@@ -17,21 +17,36 @@ public extension UIViewController {
     }
     
     func retrieveBidderDetailsSignal(emailSignal: RACSignal) -> RACSignal {
-        return emailSignal.doNext { _ -> Void in
+        return emailSignal.doNext { (thing) -> Void in
             // TODO: Show spinner for user
+            println("Got1: \(thing)")
         }.map { (email) -> AnyObject! in
             let endpoint: ArtsyAPI = ArtsyAPI.BidderDetailsNotification(auctionID: appDelegate().appViewController.sale.id, identifier: (email as String))
             
             return XAppRequest(endpoint, provider: Provider.sharedProvider, method: .PUT, parameters: endpoint.defaultParameters).filterSuccessfulStatusCodes()
-        }.doNext { _ -> Void in
-            // TODO: Show success
+        }.switchToLatest().doCompleted { _ -> Void in
+            self.presentViewController(UIAlertController.successfulBidderDetailsAlertController(), animated: true, completion: nil)
         }.doError { _ -> Void in
-            // TODO: Show error
+            self.presentViewController(UIAlertController.failedBidderDetailsAlertController(), animated: true, completion: nil)
         }
     }
 }
 
 extension UIAlertController {
+    class func successfulBidderDetailsAlertController() -> UIAlertController {
+        let alertController = self(title: "Your details have been sent", message: nil, preferredStyle: .Alert)
+        alertController.addAction(RACAlertAction(title: "OK", style: .Default))
+        
+        return alertController
+    }
+    
+    class func failedBidderDetailsAlertController() -> UIAlertController {
+        let alertController = self(title: "Incorrect Email", message: "Enter your email address registered with Artsy and we will send your bidder number and PIN.", preferredStyle: .Alert)
+        alertController.addAction(RACAlertAction(title: "OK", style: .Default))
+        
+        return alertController
+    }
+    
     class func emailPromptAlertController() -> (UIAlertController, RACCommand) {
         let alertController = self(title: "Send Bidder Details", message: "Enter your email address registered with Artsy and we will send your bidder number and PIN.", preferredStyle: .Alert)
 

--- a/Kiosk/App/BidderDetailsRetrieval.swift
+++ b/Kiosk/App/BidderDetailsRetrieval.swift
@@ -44,7 +44,12 @@ extension UIAlertController {
     
     class func failedBidderDetailsAlertController() -> UIAlertController {
         let alertController = self(title: "Incorrect Email", message: "Email was not recognized. You may not be registered to bid yet.", preferredStyle: .Alert)
-        alertController.addAction(RACAlertAction(title: "OK", style: .Default))
+        alertController.addAction(RACAlertAction(title: "Cancel", style: .Cancel))
+        
+        let retryAction = RACAlertAction(title: "Retry", style: .Default)
+        retryAction.rac_command = appDelegate().requestBidderDetailsCommand()
+        
+        alertController.addAction(retryAction)
         
         return alertController
     }

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -13,8 +13,10 @@ public enum ArtsyAPI {
     
     case MyCreditCards
     case CreatePINForBidder(bidderID: String)
-    case FindBidderRegistration(auctionID: String, phone: String)
     case RegisterToBid(auctionID: String)
+
+    
+    case FindBidderRegistration(auctionID: String, phone: String)
 
     case Artwork(id: String)
     case Artist(id: String)

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -13,10 +13,8 @@ public enum ArtsyAPI {
     
     case MyCreditCards
     case CreatePINForBidder(bidderID: String)
-    case RegisterToBid(auctionID: String)
-
-    
     case FindBidderRegistration(auctionID: String, phone: String)
+    case RegisterToBid(auctionID: String)
 
     case Artwork(id: String)
     case Artist(id: String)
@@ -36,7 +34,8 @@ public enum ArtsyAPI {
 
     case RegisterCard(balancedToken: String)
 
-    case LostPINNotification(auctionID: String, number: String)
+    case BidderDetailsNotification(auctionID: String, identifier: String)
+    
     case LostPasswordNotification(email: String)
     case FindExistingEmailRegistration(email: String)
 
@@ -94,8 +93,8 @@ public enum ArtsyAPI {
         case FindBidderRegistration(let auctionID, let phone):
             return ["sale_id": auctionID, "number": phone]
 
-        case LostPINNotification(let auctionID, let number):
-            return ["sale_id": auctionID, "number": number]
+        case BidderDetailsNotification(let auctionID, let identifier):
+            return ["sale_id": auctionID, "identifier": identifier]
 
         case LostPasswordNotification(let email):
             return ["email": email]
@@ -191,8 +190,8 @@ extension ArtsyAPI : MoyaPath {
         case TrustToken:
             return "/api/v1/me/trust_token"
 
-        case LostPINNotification:
-            return "/api/v1/bidder/pin_notification"
+        case BidderDetailsNotification:
+            return "/api/v1/bidder/bidding_details_notification"
 
         case LostPasswordNotification:
             return "/api/v1/users/send_reset_password_instructions"
@@ -273,7 +272,7 @@ extension ArtsyAPI : MoyaTarget {
         case RegisterCard:
             return stubbedResponse("RegisterCard")
 
-        case LostPINNotification:
+        case BidderDetailsNotification:
             return stubbedResponse("RegisterToBid")
 
         case LostPasswordNotification:

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -90,6 +90,7 @@ public class ConfirmYourBidPINViewController: UIViewController {
         self.presentViewController(alertController, animated: true) {}
 
         XAppRequest(endpoint, provider: Provider.sharedProvider, method: .PUT, parameters: endpoint.defaultParameters).filterSuccessfulStatusCodes().subscribeNext { (_) -> Void in
+            // Necessary to subscribe to the actual signal. This should be in a RACCommand of the button, instead. 
             println("sent")
         }
     }

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -80,7 +80,7 @@ public class ConfirmYourBidPINViewController: UIViewController {
     @IBAction func forgotPINTapped(sender: AnyObject) {
         let auctionID = fulfillmentNav().auctionID
         let number = fulfillmentNav().bidDetails.newUser.phoneNumber ?? ""
-        let endpoint: ArtsyAPI = ArtsyAPI.LostPINNotification(auctionID: auctionID, number: number)
+        let endpoint: ArtsyAPI = ArtsyAPI.BidderDetailsNotification(auctionID: auctionID, identifier: number)
 
         let alertController = UIAlertController(title: "Forgot PIN", message: "We have sent your bidder details to your device.", preferredStyle: .Alert)
 

--- a/Kiosk/Supporting Files/Info.plist
+++ b/Kiosk/Supporting Files/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2015.02.13</string>
+	<string>2015.02.26</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 	xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration '$(CONFIGURATION)' clean
 
 test:
-	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug build test -sdk iphonesimulator -destination $(DEVICE_HOST) | xcpretty --test
+	xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug build test -sdk iphonesimulator -destination $(DEVICE_HOST) | grep -i err
 
 ipa:
 	$(PLIST_BUDDY) -c "Set CFBundleDisplayName $(BUNDLE_NAME)" $(APP_PLIST)

--- a/Podfile
+++ b/Podfile
@@ -61,6 +61,7 @@ pod 'XNGMarkdownParser'
 pod 'SwiftyJSON'
 pod 'Alamofire'
 pod 'ReactiveCocoa', '3.0.0-alpha.1'
+pod 'RACAlertAction'
 pod 'Moya/Reactive'
 pod 'Swift-RAC-Macros'
 

--- a/Podfile
+++ b/Podfile
@@ -41,6 +41,7 @@ pod 'FLKAutoLayout'
 pod 'ISO8601DateFormatter', '0.7'
 pod 'ARCollectionViewMasonryLayout', '~> 2.0.0'
 pod 'SDWebImage', '~> 3.7'
+pod 'SVProgressHUD', :git => 'https://github.com/ashfurrow/SVProgressHUD.git'
 
 pod 'HockeySDK'
 pod 'ARAnalytics/Mixpanel'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,7 +53,7 @@ PODS:
   - ORStackView (2.0.0):
     - FLKAutoLayout (~> 0.1)
   - Quick (0.2.2)
-  - RACAlertAction (0.0.2):
+  - RACAlertAction (0.1.0):
     - ReactiveCocoa
   - Reachability (3.1.1)
   - ReactiveCocoa (3.0.0-alpha.1):
@@ -183,7 +183,7 @@ SPEC CHECKSUMS:
   NJKWebViewProgress: 721b57080c840c76f70ff6c2dda4f836ee1b27c1
   ORStackView: b6ccb2d7a1730548631a8a2749ba3c1bf12168db
   Quick: 7b89ff625e72ef931c2a9ef2f25ac3a9d2457763
-  RACAlertAction: de99b2092590a7364b70315b15d967c74e000d6a
+  RACAlertAction: 0187fba232f03b5f8f4f4ecc2f09b6a64e419da9
   Reachability: 2fc2badcac191cd1a15044bc7fe45aa96c499ece
   ReactiveCocoa: 3b5e351bb3ab233d71f0329f36a7400af30d9783
   SDWebImage: 116e88633b5b416ea0ca4b334a4ac59cf72dd38d

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,6 +53,8 @@ PODS:
   - ORStackView (2.0.0):
     - FLKAutoLayout (~> 0.1)
   - Quick (0.2.2)
+  - RACAlertAction (0.0.2):
+    - ReactiveCocoa
   - Reachability (3.1.1)
   - ReactiveCocoa (3.0.0-alpha.1):
     - LlamaKit (= 0.1.1)
@@ -100,6 +102,7 @@ DEPENDENCIES:
   - Nimble-Snapshots
   - ORStackView
   - Quick
+  - RACAlertAction
   - Reachability (from `https://github.com/ashfurrow/Reachability.git`, branch `frameworks`)
   - ReactiveCocoa (= 3.0.0-alpha.1)
   - SDWebImage (~> 3.7)
@@ -173,6 +176,7 @@ SPEC CHECKSUMS:
   NJKWebViewProgress: 721b57080c840c76f70ff6c2dda4f836ee1b27c1
   ORStackView: b6ccb2d7a1730548631a8a2749ba3c1bf12168db
   Quick: 7b89ff625e72ef931c2a9ef2f25ac3a9d2457763
+  RACAlertAction: de99b2092590a7364b70315b15d967c74e000d6a
   Reachability: 2fc2badcac191cd1a15044bc7fe45aa96c499ece
   ReactiveCocoa: 3b5e351bb3ab233d71f0329f36a7400af30d9783
   SDWebImage: 116e88633b5b416ea0ca4b334a4ac59cf72dd38d

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,6 +70,7 @@ PODS:
   - SDWebImage (3.7.1):
     - SDWebImage/Core (= 3.7.1)
   - SDWebImage/Core (3.7.1)
+  - SVProgressHUD (1.1.2)
   - Swift-RAC-Macros (0.2.1):
     - ReactiveCocoa (= 3.0.0-alpha.1)
   - SwiftyJSON (2.1.3)
@@ -106,6 +107,7 @@ DEPENDENCIES:
   - Reachability (from `https://github.com/ashfurrow/Reachability.git`, branch `frameworks`)
   - ReactiveCocoa (= 3.0.0-alpha.1)
   - SDWebImage (~> 3.7)
+  - SVProgressHUD (from `https://github.com/ashfurrow/SVProgressHUD.git`)
   - Swift-RAC-Macros
   - SwiftyJSON
   - UIImageViewAligned (from `https://github.com/ashfurrow/UIImageViewAligned.git`)
@@ -125,6 +127,8 @@ EXTERNAL SOURCES:
   Reachability:
     :branch: frameworks
     :git: https://github.com/ashfurrow/Reachability.git
+  SVProgressHUD:
+    :git: https://github.com/ashfurrow/SVProgressHUD.git
   UIImageViewAligned:
     :git: https://github.com/ashfurrow/UIImageViewAligned.git
 
@@ -144,6 +148,9 @@ CHECKOUT OPTIONS:
   Reachability:
     :commit: 6db8c29565c319f59174dd63e4b1ac5b471d133a
     :git: https://github.com/ashfurrow/Reachability.git
+  SVProgressHUD:
+    :commit: 72adf891646bd74a9b7478e677b8c7c1b5187443
+    :git: https://github.com/ashfurrow/SVProgressHUD.git
   UIImageViewAligned:
     :commit: 6f8cb5669b219ef08c90c2e2e5a082cadfe7565b
     :git: https://github.com/ashfurrow/UIImageViewAligned.git
@@ -180,6 +187,7 @@ SPEC CHECKSUMS:
   Reachability: 2fc2badcac191cd1a15044bc7fe45aa96c499ece
   ReactiveCocoa: 3b5e351bb3ab233d71f0329f36a7400af30d9783
   SDWebImage: 116e88633b5b416ea0ca4b334a4ac59cf72dd38d
+  SVProgressHUD: 3afb875b9eb23acd1bed9b82495695c68621a8b2
   Swift-RAC-Macros: 9fdd025f20cb97e8d6426bdd8eb26bbcbd3e0b21
   SwiftyJSON: 48be7490a3989a58a3f511cd54167f0a2b466e76
   UIImageViewAligned: 5726c9651898342c19588a02e2115cace59342ee


### PR DESCRIPTION
Fixes #357. Obviously still a work in progress :)

@katarinabatina Between the user entering their email and us showing a confirmation screen, there is going to be a delay (we need to get a confirmation from the API about whether or not this user is even registered). What should we show in the interim? Might last anywhere from 100ms to several seconds, depending on network connection speed. Maybe something like [this](https://github.com/TransitApp/SVProgressHUD)?

Next steps:

- [x] Remove call to old, removed API
- [x] Call new API
- [x] Figure out interim UI
- [x] Retry ability 