### PR TITLE
@1aurabrown => Removes more uses of toEventually()

### DIFF
--- a/KioskTests/Bid Fulfillment/KeypadViewModelTests.swift
+++ b/KioskTests/Bid Fulfillment/KeypadViewModelTests.swift
@@ -29,78 +29,73 @@ class KeypadViewModelTests: QuickSpec {
         }
         
         it("adds digits") {
-            RAC(testHarness, "stringValue") <~ subject.stringValueSignal
-            RAC(testHarness, "intValue") <~ subject.intValueSignal
-            
-            var completed = false
-
-            [1,3,3,7].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
-                signal.then { subject.addDigitCommand.execute(input) }
-            }).subscribeCompleted { () -> Void in
-                expect(testHarness.intValue) == 1337
-                expect(testHarness.stringValue) == "1337"
+            waitUntil { (done) -> Void in
+                RAC(testHarness, "stringValue") <~ subject.stringValueSignal
+                RAC(testHarness, "intValue") <~ subject.intValueSignal
                 
-                completed = true
+                [1,3,3,7].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
+                    signal.then { subject.addDigitCommand.execute(input) }
+                }).subscribeCompleted { () -> Void in
+                    expect(testHarness.intValue) == 1337
+                    expect(testHarness.stringValue) == "1337"
+                    
+                    done()
+                }
             }
-            
-            expect{ completed }.toEventually( beTruthy() )
         }
         
         it("handles prepended zeros") {
-            RAC(testHarness, "stringValue") <~ subject.stringValueSignal
-            RAC(testHarness, "intValue") <~ subject.intValueSignal
-            
-            var completed = false
-            [0,1,3,3,7].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
-                signal.then { subject.addDigitCommand.execute(input) }
-            }).subscribeCompleted { () -> Void in
-                expect(testHarness.intValue) == 1337
-                expect(testHarness.stringValue) == "01337"
+            waitUntil { (done) -> Void in
+                RAC(testHarness, "stringValue") <~ subject.stringValueSignal
+                RAC(testHarness, "intValue") <~ subject.intValueSignal
                 
-                completed = true
+                [0,1,3,3,7].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
+                    signal.then { subject.addDigitCommand.execute(input) }
+                }).subscribeCompleted { () -> Void in
+                    expect(testHarness.intValue) == 1337
+                    expect(testHarness.stringValue) == "01337"
+                    
+                    done()
+                }
             }
-            
-            expect{ completed }.toEventually( beTruthy() )
         }
         
         it("clears") {
-            RAC(testHarness, "stringValue") <~ subject.stringValueSignal
-            RAC(testHarness, "intValue") <~ subject.intValueSignal
-            
-            var completed = false
-            
-            RACSignal.empty().then {
-                subject.addDigitCommand.execute(1)
-            }.then {
-                subject.clearCommand.execute(nil)
-            }.subscribeCompleted { () -> Void in
-                expect(testHarness.intValue) == 0
-                expect(testHarness.stringValue) == ""
+            waitUntil { (done) -> Void in
+                RAC(testHarness, "stringValue") <~ subject.stringValueSignal
+                RAC(testHarness, "intValue") <~ subject.intValueSignal
                 
-                completed = true
+                RACSignal.empty().then {
+                    subject.addDigitCommand.execute(1)
+                }.then {
+                    subject.clearCommand.execute(nil)
+                }.subscribeCompleted { () -> Void in
+                    expect(testHarness.intValue) == 0
+                    expect(testHarness.stringValue) == ""
+                    
+                    done()
+                }
             }
-            
-            expect{ completed }.toEventually( beTruthy() )
         }
         
         it("deletes") {
-            RAC(testHarness, "stringValue") <~ subject.stringValueSignal
-            RAC(testHarness, "intValue") <~ subject.intValueSignal
-            
-            var completed = false
-            
-            [1,3,3].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
-                signal.then { subject.addDigitCommand.execute(input) }
-            }).then {
-                subject.deleteCommand.execute(nil)
-            }.subscribeCompleted { () -> Void in
-                expect(testHarness.intValue) == 13
-                expect(testHarness.stringValue) == "13"
+            waitUntil { (done) -> Void in
+                RAC(testHarness, "stringValue") <~ subject.stringValueSignal
+                RAC(testHarness, "intValue") <~ subject.intValueSignal
                 
-                completed = true
+                var completed = false
+                
+                [1,3,3].reduce(RACSignal.empty(), combine: { (signal, input) -> RACSignal in
+                    signal.then { subject.addDigitCommand.execute(input) }
+                }).then {
+                    subject.deleteCommand.execute(nil)
+                }.subscribeCompleted { () -> Void in
+                    expect(testHarness.intValue) == 13
+                    expect(testHarness.stringValue) == "13"
+                    
+                    done()
+                }
             }
-            
-            expect{ completed }.toEventually( beTruthy() )
         }
     }
 }


### PR DESCRIPTION
Same tests, just without `toEventually`.

![Finally found a GIF good enough for this](http://iambrony.dget.cc/mlp/gif/67613__safe_rarity_animated.gif)