### PR TITLE
@orta => Fixes synching during tests.

### DIFF
--- a/KioskTests/ListingsViewControllerTests.swift
+++ b/KioskTests/ListingsViewControllerTests.swift
@@ -172,7 +172,7 @@ func testListingsViewController(storyboard: UIStoryboard = auctionStoryboard) ->
     subject.schedule = testSchedule
     subject.auctionID = ""
     subject.switchView.shouldAnimate = false
-    subject.forceSync = true
+    subject.logSync = { _ -> () in  }
     
     return subject
 }


### PR DESCRIPTION
We were never actually hitting the network, but we were also ignoring the `forceSync` property. I replaced it with a closure that logs the syncing behaviour, which is overridden with an empty closure during tests. Also cleaned up a few extraneous brackets. 

Fixes #390.