### PR TITLE
@orta => Fixes messaging surrounding cancel/back button titles

### DIFF
--- a/Kiosk/App/Models/Image.swift
+++ b/Kiosk/App/Models/Image.swift
@@ -55,7 +55,18 @@ public class Image: JSONAble {
     }
 
     public func thumbnailURL() -> NSURL? {
-        return urlFromPreferenceList(["medium", "large", "larger"])
+        let preferredVersions = { () -> Array<String> in
+            // This is a hack for https://www.artsy.net/artwork/keith-winstein-qrpff
+            // It's a very tall image and the "medium" version looks terribad.
+            // Will work on a more general-purpose, long-term solution with our designers.
+            if self.id == "5509bd3b7261692aeeb20500" {
+                return ["large", "larger"]
+            } else {
+                return ["medium", "large", "larger"]
+            }
+        }()
+
+        return urlFromPreferenceList(preferredVersions)
     }
 
     public func fullsizeURL() -> NSURL? {

--- a/Kiosk/Bid Fulfillment/LoadingViewController.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewController.swift
@@ -133,6 +133,7 @@ public class LoadingViewController: UIViewController {
     func handleRegistered() {
         titleLabel.text = "Registration Complete"
         bidConfirmationImageView.image = UIImage(named: "BidHighestBidder")
+        fulfillmentContainer()?.cancelButton.setTitle("Done", forState: .Normal)
     }
 
     func handleUnknownBidder() {
@@ -151,8 +152,9 @@ public class LoadingViewController: UIViewController {
         titleLabel.text = "High Bid!"
         statusMessage.hidden = false
         // TODO: improve this message
-        statusMessage.text = "You are are the high bidder for this lot."
+        statusMessage.text = "You are the high bidder for this lot."
         bidConfirmationImageView.image = UIImage(named: "BidHighestBidder")
+        fulfillmentContainer()?.cancelButton.setTitle("Done", forState: .Normal)
     }
 
     func handleLowestBidder() {

--- a/Kiosk/Supporting Files/Info.plist
+++ b/Kiosk/Supporting Files/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2015.02.27</string>
+	<string>2015.03.26</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # End User Changes
 
+### 3.2 March 26 2015
+* Fix for lots with multiple images
+* Help menu bug fixed
+* Interface messaging improvements
+* New icon
+
+### 3.1.1 Feb 27 2015
+* Buyers Premium
+
 ### 2.3.2 21 Nov 2014
 * Reserve-handling - @ashfurrow
 


### PR DESCRIPTION
We don't want to confuse users by having a button entitled "Cancel" on a confirmation screen. 

This needs:

- Better abstraction in the long-term (#406)
- Regenerated snapshots, that I can't do since I don't have the 8.1 simulator at home and my internet is :dog: slow (#405)

Fixes #373, and a small typo.