### PR TITLE
@orta => Fixes crash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Allows registration with email addresses containing plus signs.
 * New and improved bidder registration details screen.
 * Removed interstitial screen between registration confirmation and showing bidder details.
-* Bidder details screen no longer hides PIN.
 * Fixes potential crash for existing users signing in with phone numbers.
+* Bidder details screen no longer hides PIN.
 
 ## 3.4.0 April 13 2015
 * Fixes problems entering in phone numbers.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * New and improved bidder registration details screen.
 * Removed interstitial screen between registration confirmation and showing bidder details.
 * Bidder details screen no longer hides PIN.
+* Fixes potential crash for existing users signing in with phone numbers.
 
 ## 3.4.0 April 13 2015
 * Fixes problems entering in phone numbers.


### PR DESCRIPTION
Basically what we do now is end the subscription (the binding) whenever the command sends `true` on `executing`, indicating that it has started executing (we ignore `false`). Since the first invocation of the command necessarily moves to one of two new controllers, we should be good :shipit: 

Fixes #444.