### PR TITLE
Removed `team_id` as `team_name` is provided already

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,4 +1,3 @@
 app_identifier "net.artsy.kiosk.beta"
 apple_id "it+appleenterprise@artsymail.com"
 team_name "ART SY INC"
-team_id "ZH8TGFYKDK"


### PR DESCRIPTION
Please test it first, but if the name is provided correctly, there is no need to provide the ID.