### PR TITLE
Use StoryboardNames enum to identify storyboards instead of 'hardcoded strings'

### DIFF
--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -36,7 +36,7 @@ public class AppDelegate: UIResponder, UIApplicationDelegate {
         defaults.removeObjectForKey(XAppToken.DefaultsKeys.TokenKey.rawValue)
         defaults.removeObjectForKey(XAppToken.DefaultsKeys.TokenExpiry.rawValue)
 
-        let auctionStoryboard = UIStoryboard(name: "Auction", bundle: nil)
+        let auctionStoryboard = UIStoryboard.auction()
         window.rootViewController = auctionStoryboard.instantiateInitialViewController() as? UIViewController
         window.makeKeyAndVisible()
 

--- a/Kiosk/Storyboards/UIStoryboardExtensions.swift
+++ b/Kiosk/Storyboards/UIStoryboardExtensions.swift
@@ -3,11 +3,11 @@ import UIKit
 public extension UIStoryboard {
     
     public class func auction() -> UIStoryboard {
-        return UIStoryboard(name: "Auction", bundle: nil)
+        return UIStoryboard(name: StoryboardNames.Auction.rawValue, bundle: nil)
     }
 
     public class func fulfillment() -> UIStoryboard {
-        return UIStoryboard(name: "Fulfillment", bundle: nil)
+        return UIStoryboard(name: StoryboardNames.Fulfillment.rawValue, bundle: nil)
     }
 
     public func viewControllerWithID(identifier:ViewControllerStoryboardIdentifier) -> UIViewController {


### PR DESCRIPTION
Thanks to eidolon project I discovered ```sbconstants``` command, and it looks really interesting to be aware of changes in storyboards identifiers.
Using that identifiers instead of "raw strings", do that when they change, compiler tell us that something was wrong, so it's better to use these identifiers.