### PR TITLE
@sarahscott => corrects reserve state

### DIFF
--- a/Kiosk/App/Models/SaleArtwork.swift
+++ b/Kiosk/App/Models/SaleArtwork.swift
@@ -124,8 +124,9 @@ public class SaleArtwork: JSONAble {
 
     // The language used here is very specific – see https://github.com/artsy/eidolon/pull/325#issuecomment-64121996 for details
     public var numberOfBidsWithReserveSignal: RACSignal {
-        return RACSignal.combineLatest([numberOfBidsSignal, RACObserve(self, "reserveStatus")]).map { (object) -> AnyObject! in
-            let tuple = object as! RACTuple
+        return RACSignal.combineLatest([numberOfBidsSignal, RACObserve(self, "reserveStatus"), RACObserve(self, "highestBidCents")]).map { (object) -> AnyObject! in
+            let tuple = object as! RACTuple // Ignoring highestBidCents; only there to trigger on bid update.
+
             let numberOfBidsString = tuple.first as! String
             let reserveStatus = ReserveStatus.initOrDefault(tuple.second as? String)
 

--- a/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
+++ b/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
@@ -359,8 +359,8 @@ public class SaleArtworkDetailsViewController: UIViewController {
             if let blurb = artist.blurb {
                 return RACSignal.`return`(blurb)
             } else {
-                let endpoint: ArtsyAPI = ArtsyAPI.Artist(id: artist.id)
-                return artistInfoSignal.map{ (json) -> AnyObject! in
+                let artistSignal = XAppRequest(.Artist(id: artist.id)).filterSuccessfulStatusCodes().mapJSON()
+                return artistSignal.map{ (json) -> AnyObject! in
                     return json["blurb"]
                     }.filter({ (blurb) -> Bool in
                         blurb != nil

--- a/KioskTests/Models/SaleArtworkTests.swift
+++ b/KioskTests/Models/SaleArtworkTests.swift
@@ -4,14 +4,14 @@ import Kiosk
 
 class SaleArtworkTests: QuickSpec {
     override func spec() {
-        describe("estimates") {
-            var saleArtwork: SaleArtwork!
-            beforeEach {
 
-                let artwork = Artwork.fromJSON([:]) as! Artwork
-                saleArtwork = SaleArtwork(id: "id", artwork: artwork)
-            }
-            
+        var saleArtwork: SaleArtwork!
+        beforeEach {
+            let artwork = Artwork.fromJSON([:]) as! Artwork
+            saleArtwork = SaleArtwork(id: "id", artwork: artwork)
+        }
+
+        describe("estimates") {
             it("gives no estimtates when no estimates present") {
                 expect(saleArtwork.estimateString) == "No Estimate"
             }
@@ -30,6 +30,87 @@ class SaleArtworkTests: QuickSpec {
             it("gives estimtates when high is present") {
                 saleArtwork.highEstimateCents = 200_00
                 expect(saleArtwork.estimateString) == "Estimate: $200"
+            }
+        }
+
+        describe("reserve status") {
+            it("gives default number of bids") {
+                let reserveStatus = saleArtwork.numberOfBidsWithReserveSignal.first() as! String
+
+                expect(reserveStatus) == "0 bids placed"
+            }
+
+            describe("with some bids") { () -> Void in
+                beforeEach {
+                    saleArtwork.bidCount = 1
+                }
+
+                it("gives default number of bids") {
+                    let reserveStatus = saleArtwork.numberOfBidsWithReserveSignal.first() as! String
+
+                    expect(reserveStatus) == "1 bid placed"
+                }
+
+                it("updates reserve status when reserve status changes") {
+
+                    var reserveStatus = ""
+                    saleArtwork.numberOfBidsWithReserveSignal.subscribeNext { (newReserveStatus) -> Void in
+                        reserveStatus = newReserveStatus as! String
+                    }
+
+                    saleArtwork.reserveStatus = ReserveStatus.ReserveNotMet.rawValue
+
+                    expect(reserveStatus) == "(1 bid placed, Reserve not met)"
+                }
+
+
+                it("sends new status when reserve status changes") {
+                    var invocations = 0
+                    saleArtwork.numberOfBidsWithReserveSignal.subscribeNext { (newReserveStatus) -> Void in
+                        invocations++
+                    }
+                    
+                    saleArtwork.reserveStatus = ReserveStatus.ReserveNotMet.rawValue
+
+                    // Once for initial subscription, another for update.
+                    expect(invocations) == 2
+                }
+
+                it("updates reserve status when number of bids changes") {
+
+                    var reserveStatus = ""
+                    saleArtwork.numberOfBidsWithReserveSignal.subscribeNext { (newReserveStatus) -> Void in
+                        reserveStatus = newReserveStatus as! String
+                    }
+
+                    saleArtwork.bidCount = 2
+
+                    expect(reserveStatus) == "2 bids placed"
+                }
+
+                it("sends new status when number of bids changes") {
+                    var invocations = 0
+                    saleArtwork.numberOfBidsWithReserveSignal.subscribeNext { (newReserveStatus) -> Void in
+                        invocations++
+                    }
+
+                    saleArtwork.bidCount = 2
+
+                    // Once for initial subscription, another for update.
+                    expect(invocations) == 2
+                }
+
+                it("sends new status when highest bid changes") {
+                    var invocations = 0
+                    saleArtwork.numberOfBidsWithReserveSignal.subscribeNext { (newReserveStatus) -> Void in
+                        invocations++
+                    }
+
+                    saleArtwork.highestBidCents = 1_00
+
+                    // Once for initial subscription, another for update.
+                    expect(invocations) == 2
+                }
             }
         }
     }


### PR DESCRIPTION
This is tricky. Fixes #456.

Basically, this PR only "fixes" the problem _if_ the number of bids stayed the same but the reserve changed, which doesn't seem likely. Additionally, the code path that updates the highest bid (that is definitely happening) is the same path that updates the reserve status, so for my hypothesis to be correct, the model returned from the API must have the wrong reserve status anyway, which is super unlikely. 

But, I added some tests and fixed an incidental bug, so submitting.

> Note: CI is going to fail, since Travis and Circle are both flailing. 