### PR TITLE
@alloy => Manual CC Entry Problem 📱

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -721,8 +721,6 @@
 				5E82BD341AF2C6E700CB02DD /* YourBiddingDetailsViewControllerTests.swift */,
 				5E8610CF1A5C43EF00456E41 /* PlaceBidViewControllerTests.swift */,
 				5EDD04D11AA69D2700B30AE9 /* KeypadViewModelTests.swift */,
-				5EF71E821AE9B6A80069A266 /* StripeManagerTests.swift */,
-				5EF71E861AE9B6EC0069A266 /* ManualCreditCardInputViewModelTests.swift */,
 			);
 			path = "Bid Fulfillment";
 			sourceTree = "<group>";
@@ -841,6 +839,8 @@
 				5E43C3911AE191D400A5A3B6 /* RegistrationPasswordViewControllerTests.swift */,
 				5E43C3931AE191DE00A5A3B6 /* RegistrationPostalZipViewControllerTests.swift */,
 				5E38FD2F1AF21ABA00D30C17 /* SwipeCreditCardViewControllerTests.swift */,
+				5EF71E821AE9B6A80069A266 /* StripeManagerTests.swift */,
+				5EF71E861AE9B6EC0069A266 /* ManualCreditCardInputViewModelTests.swift */,
 				5EF71E841AE9B6CE0069A266 /* ManualCreditCardInputViewControllerTests.swift */,
 			);
 			name = Registration;

--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewController.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewController.swift
@@ -38,7 +38,7 @@ public class ManualCreditCardInputViewController: UIViewController, Registration
         dateConfirmButton.rac_command = viewModel.registerButtonCommand()
         RAC(errorLabel, "hidden") <~ dateConfirmButton.rac_command.errors.take(1).mapReplace(false).startWith(true)
 
-        viewModel.moveToYearSignal.subscribeNext { [weak self] _ -> Void in
+        viewModel.moveToYearSignal.take(1).subscribeNext { [weak self] _ -> Void in
             self?.expirationYearTextField.becomeFirstResponder()
             return
         }

--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewController.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewController.swift
@@ -21,7 +21,7 @@ public class ManualCreditCardInputViewController: UIViewController, Registration
 
     public lazy var viewModel: ManualCreditCardInputViewModel = {
         var bidDetails = self.navigationController?.fulfillmentNav().bidDetails
-        return ManualCreditCardInputViewModel(bidDetails: bidDetails)
+        return ManualCreditCardInputViewModel(bidDetails: bidDetails, finishedSubject: self.finishedSignal)
     }()
 
     public override func viewDidLoad() {

--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
@@ -40,7 +40,8 @@ public class ManualCreditCardInputViewModel: NSObject {
 
     public func registerButtonCommand() -> RACCommand {
         let newUser = bidDetails.newUser
-        return RACCommand(enabled: self.creditCardNumberIsValidSignal) { [weak self] _ in
+        let enabled = RACSignal.combineLatest([creditCardNumberIsValidSignal, expiryDatesAreValidSignal]).and()
+        return RACCommand(enabled: enabled) { [weak self] _ in
             self?.registerCardSignal(newUser) ?? RACSignal.empty()
         }
     }

--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
@@ -12,13 +12,15 @@ public class ManualCreditCardInputViewModel: NSObject {
     public dynamic var expirationYear = ""
 
     public private(set) var bidDetails: BidDetails!
+    public private(set) var finishedSubject: RACSubject?
 
     /// Mark: - Public members
 
-    public init(bidDetails: BidDetails!) {
+    public init(bidDetails: BidDetails!, finishedSubject: RACSubject? = nil) {
         super.init()
 
         self.bidDetails = bidDetails
+        self.finishedSubject = finishedSubject
     }
 
     public var creditCardNumberIsValidSignal: RACSignal {
@@ -42,7 +44,9 @@ public class ManualCreditCardInputViewModel: NSObject {
         let newUser = bidDetails.newUser
         let enabled = RACSignal.combineLatest([creditCardNumberIsValidSignal, expiryDatesAreValidSignal]).and()
         return RACCommand(enabled: enabled) { [weak self] _ in
-            self?.registerCardSignal(newUser) ?? RACSignal.empty()
+            (self?.registerCardSignal(newUser) ?? RACSignal.empty())?.doCompleted { () -> Void in
+                self?.finishedSubject?.sendCompleted()
+            }
         }
     }
 

--- a/Kiosk/Storyboards/Auction.storyboard
+++ b/Kiosk/Storyboards/Auction.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="KCM-cT-BEX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="KCM-cT-BEX">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -638,7 +638,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="2014" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gwD-26-Ys0">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="2017" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gwD-26-Ys0">
                                 <rect key="frame" x="722" y="194" width="70" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>

--- a/KioskTests/Bid Fulfillment/ManualCreditCardInputViewControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/ManualCreditCardInputViewControllerTests.swift
@@ -124,7 +124,7 @@ class ManualCreditCardInputTestViewModel: ManualCreditCardInputViewModel {
     var moveToYearSubject = RACSubject()
     var testRegisterButtonCommand: RACCommand
 
-    override init(bidDetails: BidDetails!) {
+    override init(bidDetails: BidDetails!, finishedSubject: RACSubject? = nil) {
         testRegisterButtonCommand = RACCommand(enabled: RACSignal.`return`(false)) { (subscriber) -> RACSignal! in
             return RACSignal.empty()
         }

--- a/KioskTests/Bid Fulfillment/ManualCreditCardInputViewModelTests.swift
+++ b/KioskTests/Bid Fulfillment/ManualCreditCardInputViewModelTests.swift
@@ -124,22 +124,36 @@ class ManualCreditCardInputViewModelTests: QuickSpec {
         }
 
         describe("credit card registration") { () -> () in
-            it("enables command with a valid credit card") {
+            it("enables command with a valid credit card and valid expiry dates") {
                 testStripeManager.isValidCreditCard = true
                 subject.cardFullDigits = ""
+                subject.expirationMonth = "02"
+                subject.expirationYear = "2017"
                 expect((subject.registerButtonCommand().enabled.first() as! Bool)) == true
             }
 
             it("disables command with invalid credit card") {
                 testStripeManager.isValidCreditCard = false
                 subject.cardFullDigits = ""
+                subject.expirationMonth = "02"
+                subject.expirationYear = "2017"
                 expect((subject.registerButtonCommand().enabled.first() as! Bool)) == false
             }
 
-            describe("a valid card") {
+            it("disables command with invalid expiry date") {
+                testStripeManager.isValidCreditCard = false
+                subject.cardFullDigits = ""
+                subject.expirationMonth = "02"
+                subject.expirationYear = "207"
+                expect((subject.registerButtonCommand().enabled.first() as! Bool)) == false
+            }
+
+            describe("a valid card and expiry date") {
                 beforeEach {
                     testStripeManager.isValidCreditCard = true
                     subject.cardFullDigits = ""
+                    subject.expirationMonth = "02"
+                    subject.expirationYear = "2017"
                 }
 
                 it("registers with stripe") {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fixes problem manually entering in credit card info.
+
 ## 3.5.2 June 19 2015
 * Attempts to fix problem tokenizing credit cards.
 


### PR DESCRIPTION
Crus is that we weren't sending a "complete" event to our `finishedSignal` once the CC tokenization succeeded. I added tests to ensure that the event is sent if and only if the tokenization succeeds. 

I also noticed a few other problems that I fixed and added test for, in separate commits. Should I make things like that separate PRs? Open to advice.

(Note: Circle and Travis are currently both failing to run tests. I've checked that they pass locally.)

Fixes #455.