### PR TITLE
@alloy => Adds long tap gesture for bidding error details 📱

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3FCE6D8A07CA1FA29F4A37DC /* Pods_KioskTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC6D95F6020DA76AECC315F /* Pods_KioskTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		5E0A4E3E1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */; };
 		5E19E6501A6564B300F8CBDD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E19E64E1A65630200F8CBDD /* Logger.swift */; };
 		5E19E6521A656CCF00F8CBDD /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E19E6511A656CCF00F8CBDD /* LoggerTests.swift */; };
 		5E339E3A1A991899000C773D /* RACExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E339E391A991899000C773D /* RACExtensions.swift */; };
@@ -229,6 +230,7 @@
 
 /* Begin PBXFileReference section */
 		3AC6D95F6020DA76AECC315F /* Pods_KioskTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KioskTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+LongPressDisplayMessage.swift"; path = "Kiosk/UIView+LongPressDisplayMessage.swift"; sourceTree = SOURCE_ROOT; };
 		5E19E64E1A65630200F8CBDD /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		5E19E6511A656CCF00F8CBDD /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		5E339E391A991899000C773D /* RACExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RACExtensions.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 				5E8610201A5C429C00456E41 /* toolbar_close@2x.png */,
 				5E8610211A5C429C00456E41 /* YourBiddingDetailsViewController.swift */,
 				5EBD314C1AE053ED00648484 /* Registration */,
+				5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */,
 			);
 			path = "Bid Fulfillment";
 			sourceTree = "<group>";
@@ -1204,6 +1207,7 @@
 				5E86109A1A5C429C00456E41 /* RegistrationMobileViewController.swift in Sources */,
 				5E8610681A5C429C00456E41 /* APIKeys.swift in Sources */,
 				5EFA709C1A9674BD0082C916 /* BidderDetailsRetrieval.swift in Sources */,
+				5E0A4E3E1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift in Sources */,
 				5E86108C1A5C429C00456E41 /* FulfillmentNavigationController.swift in Sources */,
 				5E8610621A5C429C00456E41 /* JSONAble.swift in Sources */,
 				5E8610721A5C429C00456E41 /* UIStoryboardSegueExtensions.swift in Sources */,
@@ -1386,7 +1390,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "5b9273b0-3d08-46f2-82cc-2ddd47c304fb";
+				PROVISIONING_PROFILE = "ebbf82db-5281-4642-9165-2749cae2e369";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kiosk/Supporting Files/BridgingHeader.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Kiosk/App/NSErrorExtensions.swift
+++ b/Kiosk/App/NSErrorExtensions.swift
@@ -1,12 +1,17 @@
 import Foundation
+import Moya
 
 extension NSError {
 
     func artsyServerError() -> NSString {
-        if let errorJSON = self.userInfo?["data"] as? [String: AnyObject] {
+        if let errorJSON = userInfo?["data"] as? [String: AnyObject] {
             let error =  GenericError.fromJSON(errorJSON) as! GenericError
             return "\(error.message) - \(error.detail) + \(error.detail)"
+        } else if let response = userInfo?["data"] as? MoyaResponse {
+            let stringData = NSString(data: response.data, encoding: NSUTF8StringEncoding)
+            return "Status Code: \(response.statusCode), Data Length: \(response.data.length), String Data: \(stringData)"
         }
-        return ""
+
+        return "\(userInfo)"
     }
 }

--- a/Kiosk/UIView+LongPressDisplayMessage.swift
+++ b/Kiosk/UIView+LongPressDisplayMessage.swift
@@ -1,0 +1,25 @@
+import UIKit
+import ReactiveCocoa
+
+private func alertController(message: String, title: String) -> UIAlertController {
+    let alertController =  UIAlertController(title: title, message: message, preferredStyle: .Alert)
+
+    alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+
+    return alertController
+}
+
+extension UIView {
+    typealias PresentAlertClosure = (alertController: UIAlertController) -> Void
+
+    func presentOnLongPress(message: String, title: String, closure: PresentAlertClosure) {
+        let recognizer = UILongPressGestureRecognizer()
+
+        recognizer.rac_gestureSignal().subscribeNext { _ -> Void in
+            closure(alertController: alertController(message, title))
+        }
+
+        userInteractionEnabled = true
+        addGestureRecognizer(recognizer)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next
-
+* Adds long-tap gesture to bidding error message to provide technical error details.
 * Fixes problem manually entering in credit card info.
 
 ## 3.5.2 June 19 2015


### PR DESCRIPTION
Adds a tap gesture recognizer to the error details label that will display an alert with the technical details, including the API response HTTP status code (if any), body length, and UTF8-encoded body string (if any).

I've produced an intentional error to generate the screenshot below:

![ios simulator screen shot jun 29 2015 3 23 18 pm](https://cloud.githubusercontent.com/assets/498212/8416511/4c98be38-1e74-11e5-8497-01bba9a99b25.png)

Tests pass locally.

Fixes #454.