### PR TITLE
@orta => Updates existing artworks sold status

### DIFF
--- a/Kiosk/App/Models/Artwork.swift
+++ b/Kiosk/App/Models/Artwork.swift
@@ -98,6 +98,11 @@ public class Artwork: JSONAble {
         return artwork
     }
 
+    public func updateWithValues(newArtwork: Artwork) {
+        // soldStatus is the only value we expect to change at runtime.
+        soldStatus = newArtwork.soldStatus
+    }
+
     func sortableArtistID() -> String {
         return artists?.first?.sortableID ?? "_"
     }

--- a/Kiosk/App/Models/SaleArtwork.swift
+++ b/Kiosk/App/Models/SaleArtwork.swift
@@ -88,6 +88,8 @@ public class SaleArtwork: JSONAble {
         bidCount = newSaleArtwork.bidCount
         reserveStatus = newSaleArtwork.reserveStatus
         lotNumber = newSaleArtwork.lotNumber ?? lotNumber
+
+        artwork.updateWithValues(newSaleArtwork.artwork)
     }
     
     public var estimateString: String {

--- a/KioskTests/Models/ArtworkTests.swift
+++ b/KioskTests/Models/ArtworkTests.swift
@@ -69,5 +69,14 @@ class ArtworkTests: QuickSpec {
 
             expect(artwork.defaultImage!.id) == "default"
         }
+
+        it("updates the soldStatus") {
+            let newArtwork = Artwork.fromJSON(data) as! Artwork
+            newArtwork.soldStatus = "sold"
+
+            artwork.updateWithValues(newArtwork)
+
+            expect(artwork.soldStatus) == "sold"
+        }
     }
 }

--- a/KioskTests/Models/SaleArtworkTests.swift
+++ b/KioskTests/Models/SaleArtworkTests.swift
@@ -11,6 +11,16 @@ class SaleArtworkTests: QuickSpec {
             saleArtwork = SaleArtwork(id: "id", artwork: artwork)
         }
 
+        it("updates the soldStatus") {
+            let newArtwork = Artwork.fromJSON([:]) as! Artwork
+            newArtwork.soldStatus = "sold"
+            let newSaleArtwork = SaleArtwork(id: "id", artwork: newArtwork)
+
+            saleArtwork.updateWithValues(newSaleArtwork)
+
+            expect(newSaleArtwork.artwork.soldStatus) == "sold"
+        }
+
         describe("estimates") {
             it("gives no estimtates when no estimates present") {
                 expect(saleArtwork.estimateString) == "No Estimate"


### PR DESCRIPTION
I realize that I made an error on [this pull request](https://github.com/artsy/eidolon/pull/477). Artworks that were sold when the app first sync'd would be marked as sold, but artworks that were updated after the first sync would not. 

I don't think it needs a changelog entry since we've not released since the PR was merged. My bad for not thinking of this scenario at the time. 