### PR TITLE
@orta: Adds new backend estimateCents field to SaleArtwork model

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,9 +1,10 @@
 upcoming: 
   version: 3.6.0
   notes:
-  - Adds long-tap gesture to bidding error message to provide technical error details.
-  - Fixes problem manually entering in credit card info.
-  - Disables bid buttons and marks them as "SOLD" for artworks that have been sold.
+  - Adds long-tap gesture to bidding error message to provide technical error details [ash]
+  - Fixes problem manually entering in credit card info [ash]
+  - Disables bid buttons and marks them as "SOLD" for artworks that have been sold [ash]
+  - Adds support for new estimate field [ash]
 releases:
 - version: 3.5.2
   date: June 19 2015

--- a/Kiosk/App/Models/SaleArtwork.swift
+++ b/Kiosk/App/Models/SaleArtwork.swift
@@ -40,6 +40,7 @@ public class SaleArtwork: JSONAble {
     public dynamic var minimumNextBidCents: NSNumber?
     
     public dynamic var highestBidCents: NSNumber?
+    public var estimateCents: Int?
     public var lowEstimateCents: Int?
     public var highEstimateCents: Int?
 
@@ -68,6 +69,7 @@ public class SaleArtwork: JSONAble {
         saleArtwork.minimumNextBidCents = json["minimum_next_bid_cents"].int
 
         saleArtwork.highestBidCents = json["highest_bid_amount_cents"].int
+        saleArtwork.estimateCents = json["estimate_cents"].int
         saleArtwork.lowEstimateCents = json["low_estimate_cents"].int
         saleArtwork.highEstimateCents = json["high_estimate_cents"].int
         saleArtwork.bidCount = json["bidder_positions_count"].int
@@ -83,6 +85,7 @@ public class SaleArtwork: JSONAble {
         openingBidCents = newSaleArtwork.openingBidCents
         minimumNextBidCents = newSaleArtwork.minimumNextBidCents
         highestBidCents = newSaleArtwork.highestBidCents
+        estimateCents = newSaleArtwork.estimateCents
         lowEstimateCents = newSaleArtwork.lowEstimateCents
         highEstimateCents = newSaleArtwork.highEstimateCents
         bidCount = newSaleArtwork.bidCount
@@ -93,17 +96,18 @@ public class SaleArtwork: JSONAble {
     }
     
     public var estimateString: String {
+        // Default to estimateCents
+        if let estimateCents = estimateCents {
+            let dollars = NSNumberFormatter.currencyStringForCents(estimateCents)
+            return "Estimate: \(dollars)"
+        }
+
+        // Try to extract non-nil low/high estimates. Return a default otherwise.
         switch (lowEstimateCents, highEstimateCents) {
         case let (.Some(lowCents), .Some(highCents)):
             let lowDollars = NSNumberFormatter.currencyStringForCents(lowCents)
             let highDollars = NSNumberFormatter.currencyStringForCents(highCents)
             return "Estimate: \(lowDollars)–\(highDollars)"
-        case let (.Some(lowCents), nil):
-            let lowDollars = NSNumberFormatter.currencyStringForCents(lowCents)
-            return "Estimate: \(lowDollars)"
-        case let (nil, .Some(highCents)):
-            let highDollars = NSNumberFormatter.currencyStringForCents(highCents)
-            return "Estimate: \(highDollars)"
         default:
             return "No Estimate"
         }

--- a/KioskTests/Models/SaleArtworkTests.swift
+++ b/KioskTests/Models/SaleArtworkTests.swift
@@ -26,20 +26,32 @@ class SaleArtworkTests: QuickSpec {
                 expect(saleArtwork.estimateString) == "No Estimate"
             }
             
-            it("gives estimtates when low and high are present") {
+            it("gives estimtate range when low and high are present") {
                 saleArtwork.lowEstimateCents = 100_00
                 saleArtwork.highEstimateCents = 200_00
                 expect(saleArtwork.estimateString) == "Estimate: $100–$200"
             }
-            
-            it("gives estimtates when low is present") {
+
+            it("gives estimate if present") {
+                saleArtwork.estimateCents = 200_00
+                expect(saleArtwork.estimateString) == "Estimate: $200"
+            }
+
+            it("give estimate if estimate both and low/high are present") {
+                saleArtwork.highEstimateCents = 300_00
                 saleArtwork.lowEstimateCents = 100_00
-                expect(saleArtwork.estimateString) == "Estimate: $100"
+                saleArtwork.estimateCents = 200_00
+                expect(saleArtwork.estimateString) == "Estimate: $200"
             }
             
-            it("gives estimtates when high is present") {
-                saleArtwork.highEstimateCents = 200_00
-                expect(saleArtwork.estimateString) == "Estimate: $200"
+            it("gives no estimate if only high is present") {
+                saleArtwork.highEstimateCents = 100_00
+                expect(saleArtwork.estimateString) == "No Estimate"
+            }
+
+            it("gives no estimate if only low is present") {
+                saleArtwork.lowEstimateCents = 100_00
+                expect(saleArtwork.estimateString) == "No Estimate"
             }
 
             it("indicates that an artwork is not for sale") {


### PR DESCRIPTION
I went looking on Google for "art auction" GIFs and was happy to see we're on the first page:

<img width="830" alt="screen shot 2015-07-24 at 2 57 19 pm" src="https://cloud.githubusercontent.com/assets/498212/8882375/661b8972-3214-11e5-944a-9993b10637f7.png">

/cc @dblock 

Fixes #474.