### PR TITLE
@orta: Lot number fix

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,7 @@
-upcoming: 
+upcoming:
+  version: 3.6.1
+  notes:
+  - Fixes problem with lot numbers changing during the auction [ash]
 releases:
   date: September 24 2015
   version: 3.6.0

--- a/Kiosk/App/Models/SaleArtworkViewModel.swift
+++ b/Kiosk/App/Models/SaleArtworkViewModel.swift
@@ -52,6 +52,10 @@ extension SaleArtworkViewModel {
         return saleArtwork.artwork.titleAndDate
     }
 
+    var saleArtworkID: String {
+        return saleArtwork.id
+    }
+
     // Signals representing values that change over time.
 
     var numberOfBidsSignal: RACSignal {

--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -157,7 +157,7 @@ class ListingsViewModel: NSObject, ListingsViewModelType {
                         if currentSaleArtworks[i].id == newSaleArtworks[i].id {
                             currentSaleArtworks[i].updateWithValues(newSaleArtworks[i])
                         } else {
-                            // Failure: the list was the same size but had different artworks
+                            // Failure: the list was the same size but had different artworks.
                             return false
                         }
                     }

--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -147,17 +147,15 @@ class ListingsViewModel: NSObject, ListingsViewModelType {
 
                 func update(currentSaleArtworks: [SaleArtwork], newSaleArtworks: [SaleArtwork]) -> Bool {
                     assert(currentSaleArtworks.count == newSaleArtworks.count, "Arrays' counts must be equal.")
-                    // Updating the currentSaleArtworks is easy. First we sort both according to the same criteria
-                    // Because we assume that their length is the same, we just do a linear scane through and
-                    // copy values from the new to the old.
+                    // Updating the currentSaleArtworks is easy. Both are already sorted as they came from the API (by lot #).
+                    // Because we assume that their length is the same, we just do a linear scan through and
+                    // copy values from the new to the existing.
 
-                    let sortedCurentSaleArtworks = currentSaleArtworks.sort(sortById)
-                    let sortedNewSaleArtworks = newSaleArtworks.sort(sortById)
+                    let saleArtworksCount = currentSaleArtworks.count
 
-                    let saleArtworksCount = sortedCurentSaleArtworks.count
                     for var i = 0; i < saleArtworksCount; i++ {
                         if currentSaleArtworks[i].id == newSaleArtworks[i].id {
-                            currentSaleArtworks[i].updateWithValues(sortedNewSaleArtworks[i])
+                            currentSaleArtworks[i].updateWithValues(newSaleArtworks[i])
                         } else {
                             // Failure: the list was the same size but had different artworks
                             return false


### PR DESCRIPTION
This fixes a bug tracked in [this Trello card](https://trello.com/c/f3GvqhJl/82-kiosk-sync-using-wrong-lot-numbers). Here's what was going on:

- We had an auction that changed the original lot numbers. 
- The initial sync displayed the correct lot details. 
- Subsequent syncs would show incorrect details. 

Here's what I think was happening (@devangt is going to confirm this afternoon):

1. On first sync, the lengths of the new sale artworks and current sale artworks differ (the latter is empty), so we just use the new data. 
2. On subsequent syncs, we checked if the arrays lengths differed (let's assume they don't). We were then sorting the new/current sale artworks by `id`, then marching through the two arrays (of equal length). If the `id`s at each index matched, then we updated the existing `SaleArtwork` instance in situ. 

The problem with step 2 is that we were updating the existing `SaleArtwork` at the index of the _unsorted_ array with the sale artwork at the same index in the _sorted_ array. Since the default sort returned by the API is by lot number, when we swapped the lot numbers of the first and second lots, subsequent syncs would apply the updates for the first lot to the second one, and vice-versa. 

The fix involves _not sorting_ at all – relying on the default sort order of the API (lot number), and if any of the IDs of the sale artworks have changed, then we replace the entire array.

Wanted to get this PR up to run this by others. **Before merging**, this needs:

- [x] Tests for breaking case.
- [x] Changelog update.