### PR TITLE
[WIP] @acjay: Fixes PIN login failures

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,7 @@ upcoming:
   notes:
   - Increases max bid to 10 000 000 [alan]
   - New safeguard to ensure Kiosk is hitting network [ash]
+  - Fixes problem logging in with bidder/phone number and pin [ash]
 releases:
 - version: 3.8.1
   date: October 9 2015

--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		5EDBB3251BAB59A000D6A6C8 /* RACAlertAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EDBB3241BAB59A000D6A6C8 /* RACAlertAction.m */; settings = {ASSET_TAGS = (); }; };
 		5EDD04D21AA69D2700B30AE9 /* KeypadViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDD04D11AA69D2700B30AE9 /* KeypadViewModelTests.swift */; };
 		5EE5B0CE1BB3479300069312 /* PlaceBidNetworkModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE5B0CD1BB3479300069312 /* PlaceBidNetworkModelTests.swift */; settings = {ASSET_TAGS = (); }; };
+		5EEAF9CA1BCD796B00C1470F /* FulfillmentNavigationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EEAF9C91BCD796B00C1470F /* FulfillmentNavigationControllerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		5EF71E781AE986000069A266 /* StripeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF71E771AE986000069A266 /* StripeManager.swift */; };
 		5EF71E7B1AE98F080069A266 /* STPCard+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EF71E7A1AE98F080069A266 /* STPCard+Validation.m */; };
 		5EF71E7D1AE996F50069A266 /* SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF71E7C1AE996F50069A266 /* SwiftExtensions.swift */; };
@@ -423,6 +424,7 @@
 		5EDBB3241BAB59A000D6A6C8 /* RACAlertAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACAlertAction.m; sourceTree = "<group>"; };
 		5EDD04D11AA69D2700B30AE9 /* KeypadViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeypadViewModelTests.swift; sourceTree = "<group>"; };
 		5EE5B0CD1BB3479300069312 /* PlaceBidNetworkModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceBidNetworkModelTests.swift; sourceTree = "<group>"; };
+		5EEAF9C91BCD796B00C1470F /* FulfillmentNavigationControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FulfillmentNavigationControllerTests.swift; sourceTree = "<group>"; };
 		5EF71E771AE986000069A266 /* StripeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StripeManager.swift; sourceTree = "<group>"; };
 		5EF71E791AE98F080069A266 /* STPCard+Validation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "STPCard+Validation.h"; sourceTree = "<group>"; };
 		5EF71E7A1AE98F080069A266 /* STPCard+Validation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "STPCard+Validation.m"; sourceTree = "<group>"; };
@@ -740,6 +742,7 @@
 				5E8610CB1A5C43EF00456E41 /* ConfirmYourBidPINViewControllerTests.swift */,
 				5E8610CC1A5C43EF00456E41 /* ConfirmYourBidViewControllerTests.swift */,
 				5E8610CD1A5C43EF00456E41 /* FulfillmentContainerViewControllerTests.swift */,
+				5EEAF9C91BCD796B00C1470F /* FulfillmentNavigationControllerTests.swift */,
 				5E8610CE1A5C43EF00456E41 /* LoadingViewControllerTests.swift */,
 				5EA6B1121B668F9300FEB3ED /* LoadingViewModelTests.swift */,
 				5E82BD341AF2C6E700CB02DD /* YourBiddingDetailsViewControllerTests.swift */,
@@ -1307,6 +1310,7 @@
 				5EF71E851AE9B6CE0069A266 /* ManualCreditCardInputViewControllerTests.swift in Sources */,
 				5E9F8AD41A8951C100CBEACE /* SaleArtworkDetailsViewControllerTests.swift in Sources */,
 				5E8611311A5C43EF00456E41 /* SwitchViewSpec.swift in Sources */,
+				5EEAF9CA1BCD796B00C1470F /* FulfillmentNavigationControllerTests.swift in Sources */,
 				5E86110A1A5C43EF00456E41 /* FulfillmentContainerViewControllerTests.swift in Sources */,
 				5E8611341A5C43EF00456E41 /* XAppTokenSpec.swift in Sources */,
 				5E38FD2E1AF2154C00D30C17 /* RACExtensionsTests.swift in Sources */,

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -60,6 +60,10 @@ class ConfirmYourBidPINViewController: UIViewController {
                 }
 
             }.doError({ [weak self] (error) -> Void in
+                if let response = error.userInfo["data"] as? MoyaResponse {
+                    let responseBody = NSString(data: response.data, encoding: NSUTF8StringEncoding)
+                    print("Error authenticating(\(response.statusCode)): \(responseBody)")
+                }
                 self?.showAuthenticationError()
                 return
             })

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -90,7 +90,8 @@ class ConfirmYourBidPINViewController: UIViewController {
 
     func providerForPIN(pin: String, number: String) -> ReactiveCocoaMoyaProvider<ArtsyAPI> {
         let newEndpointsClosure = { (target: ArtsyAPI) -> Endpoint<ArtsyAPI> in
-            let endpoint: Endpoint<ArtsyAPI> = Endpoint<ArtsyAPI>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+            // Grab existing endpoint to piggy-back off of any existing configurations being used by the sharedprovider.
+            let endpoint = Provider.sharedProvider.endpointClosure(target)
 
             let auctionID = self.fulfillmentNav().auctionID
             return endpoint.endpointByAddingParameters(["auction_pin": pin, "number": number, "sale_id": auctionID])

--- a/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
+++ b/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
@@ -26,7 +26,8 @@ class FulfillmentNavigationController: UINavigationController, FulfillmentContro
         didSet(oldToken) {
 
             let newEndpointsClosure = { (target: ArtsyAPI) -> Endpoint<ArtsyAPI> in
-                let endpoint: Endpoint<ArtsyAPI> = Endpoint<ArtsyAPI>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+                // Grab existing endpoint to piggy-back off of any existing configurations being used by the sharedprovider.
+                let endpoint = Provider.sharedProvider.endpointClosure(target)
 
                 return endpoint.endpointByAddingHTTPHeaderFields(["X-Access-Token": self.xAccessToken!])
             }
@@ -73,3 +74,4 @@ class FulfillmentNavigationController: UINavigationController, FulfillmentContro
         }
     }
 }
+

--- a/KioskTests/Bid Fulfillment/FulfillmentNavigationControllerTests.swift
+++ b/KioskTests/Bid Fulfillment/FulfillmentNavigationControllerTests.swift
@@ -1,0 +1,55 @@
+import Quick
+import Nimble
+@testable
+import Kiosk
+import Moya
+import ReactiveCocoa
+
+class FulfillmentNavigationControllerTests: QuickSpec {
+    override func spec() {
+        var subject: FulfillmentNavigationController!
+
+        let token = "I'm a token"
+
+        beforeEach {
+            subject = FulfillmentNavigationController(rootViewController: UIViewController())
+
+            subject.xAccessToken = token
+        }
+
+        afterEach {
+            Provider.sharedProvider = Provider.StubbingProvider()
+        }
+
+        it("creates a loggedInProvider when the xAccessToken is set") {
+            expect(subject.loggedInProvider).toNot( beNil() )
+        }
+
+        it("changes the logged-in provider to use xAccessToken") {
+            let target = ArtsyAPI.Me
+            let endpoint = subject.loggedInProvider!.endpointClosure(target)
+
+            expect(endpoint.urlRequest.allHTTPHeaderFields!["X-Access-Token"]) == token
+        }
+        
+        it("respects original endpoints closure") {
+            var externalClosureInvoked = false
+
+            let externalClosure = { (target: ArtsyAPI) -> Endpoint<ArtsyAPI> in
+                let endpoint = Endpoint<ArtsyAPI>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+
+                externalClosureInvoked = true
+
+                return endpoint
+            }
+
+            Provider.sharedProvider = ArtsyProvider(endpointClosure: externalClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, onlineSignal: RACSignal.`return`(true))
+
+
+            let target = ArtsyAPI.Me
+            _ = subject.loggedInProvider!.endpointClosure(target)
+
+            expect(externalClosureInvoked) == true
+        }
+    }
+}


### PR DESCRIPTION
This fixes log in with bidder/phone number and pin. The issue was that the XApp token requested and stored by the original provider wasn't being added for providers created for logged-in users. This didn't affect users logged in with Artsy credentials because they had their own auth done with username/password which is separate from the trust token endpoint. 

This still needs tests, so it's WIP for now. 