### PR TITLE
@orta: Fixes problem not displaying credentials

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,8 +1,12 @@
 upcoming:
+  version: 3.8.5
+  notes:
+  - A newly registered bidder will now be shown their details no matter how many times they get outbid [ash]
+releases:
   version: 3.8.4
+  date: October 21 2015
   notes:
   - Displays zero bids for a sale artwork that has no highest bid [ash]
-releases:
 - version: 3.8.3
   date: October 13 2015
   notes:

--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		5EB0B71C1A5C410D00B7CBF2 /* UILabel+Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB0B7171A5C410D00B7CBF2 /* UILabel+Fonts.swift */; };
 		5EB0B71D1A5C410D00B7CBF2 /* UITextField+RAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB0B7181A5C410D00B7CBF2 /* UITextField+RAC.swift */; };
 		5EB0B71E1A5C410D00B7CBF2 /* UIViewController+Bidding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB0B7191A5C410D00B7CBF2 /* UIViewController+Bidding.swift */; };
+		5EBB3C071BD7E92C0013EBC3 /* BidderNetworkModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBB3C061BD7E92C0013EBC3 /* BidderNetworkModelTests.swift */; settings = {ASSET_TAGS = (); }; };
 		5EBD31491AE0435600648484 /* GenericFormValidationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBD31481AE0435600648484 /* GenericFormValidationViewModel.swift */; };
 		5EBD314B1AE047C700648484 /* RegistrationPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBD314A1AE047C700648484 /* RegistrationPasswordViewModel.swift */; };
 		5EBD314F1AE0563300648484 /* GenericFormValidationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBD314E1AE0563300648484 /* GenericFormValidationViewModelTests.swift */; };
@@ -420,6 +421,7 @@
 		5EB0B7181A5C410D00B7CBF2 /* UITextField+RAC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+RAC.swift"; sourceTree = "<group>"; };
 		5EB0B7191A5C410D00B7CBF2 /* UIViewController+Bidding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Bidding.swift"; sourceTree = "<group>"; };
 		5EB8D8EE1A5C513A008EAD6C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5EBB3C061BD7E92C0013EBC3 /* BidderNetworkModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BidderNetworkModelTests.swift; sourceTree = "<group>"; };
 		5EBD31481AE0435600648484 /* GenericFormValidationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericFormValidationViewModel.swift; sourceTree = "<group>"; };
 		5EBD314A1AE047C700648484 /* RegistrationPasswordViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationPasswordViewModel.swift; sourceTree = "<group>"; };
 		5EBD314E1AE0563300648484 /* GenericFormValidationViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericFormValidationViewModelTests.swift; sourceTree = "<group>"; };
@@ -754,6 +756,7 @@
 				5E8610CF1A5C43EF00456E41 /* PlaceBidViewControllerTests.swift */,
 				5EDD04D11AA69D2700B30AE9 /* KeypadViewModelTests.swift */,
 				5EE5B0CD1BB3479300069312 /* PlaceBidNetworkModelTests.swift */,
+				5EBB3C061BD7E92C0013EBC3 /* BidderNetworkModelTests.swift */,
 			);
 			path = "Bid Fulfillment";
 			sourceTree = "<group>";
@@ -1292,6 +1295,7 @@
 				5E86110E1A5C43EF00456E41 /* CardHandlerTests.swift in Sources */,
 				5E43C38E1AE1917F00A5A3B6 /* RegistrationEmailViewControllerTests.swift in Sources */,
 				5E8611031A5C43EF00456E41 /* AppViewControllerTests.swift in Sources */,
+				5EBB3C071BD7E92C0013EBC3 /* BidderNetworkModelTests.swift in Sources */,
 				5E5BD1CE1BD59CC70004CFC6 /* SaleArtworkVIewModelTests.swift in Sources */,
 				5E8611131A5C43EF00456E41 /* BidderPositionTests.swift in Sources */,
 				5E8611151A5C43EF00456E41 /* BidTests.swift in Sources */,

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -331,7 +331,6 @@ func endpointResolver() -> MoyaProvider<ArtsyAPI>.RequestClosure {
 }
 
 class ArtsyProvider<Target where Target: MoyaTarget>: ReactiveCocoaMoyaProvider<Target> {
-    typealias OnlineSignalClosure = () -> RACSignal
 
     let onlineSignal: RACSignal
 

--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -73,7 +73,7 @@ class ListingsViewModel: NSObject, ListingsViewModelType {
     // MARK: Private Methods
 
     private func setup(selectedIndexSignal: RACSignal) {
-        RAC(self, "saleArtworks") <~ recurringListingsRequestSignal()
+        RAC(self, "saleArtworks") <~ recurringListingsRequestSignal().takeUntil(self.rac_willDeallocSignal())
 
         showSpinnerSignal = RACObserve(self, "saleArtworks").mapArrayLengthExistenceToBool().not()
         gridSelectedSignal = selectedIndexSignal.map { return ListingsViewModel.SwitchValues(rawValue: $0 as! Int) == .Some(.Grid) }

--- a/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
+++ b/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
@@ -1,13 +1,16 @@
 import Foundation
 import ReactiveCocoa
+import Swift_RAC_Macros
 import Moya
 
 class BidderNetworkModel: NSObject {
-    dynamic var createdNewBidder = false
-
     // MARK: - Getters
 
     var fulfillmentController: FulfillmentController
+
+    var createdNewUser: RACSignal {
+        return RACObserve(self.fulfillmentController.bidDetails.newUser, "hasBeenRegistered")
+    }
 
     init(fulfillmentController: FulfillmentController) {
         self.fulfillmentController = fulfillmentController
@@ -132,7 +135,7 @@ class BidderNetworkModel: NSObject {
         return signal.doNext{ [weak self] (bidder) in
             if let bidder = bidder as? Bidder {
                 self?.fulfillmentController.bidDetails.bidderID = bidder.id
-                self?.createdNewBidder = true
+                self?.fulfillmentController.bidDetails.newUser.hasBeenRegistered = true
             }
 
         }.doError { (error) in

--- a/Kiosk/Bid Fulfillment/LoadingViewModel.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewModel.swift
@@ -29,7 +29,7 @@ class LoadingViewModel: NSObject {
 
         super.init()
 
-        RAC(self, "createdNewBidder") <~ RACObserve(bidderNetworkModel, "createdNewBidder")
+        RAC(self, "createdNewBidder") <~ bidderNetworkModel.createdNewUser
         RAC(self, "bidIsResolved") <~ RACObserve(bidCheckingModel, "bidIsResolved")
         RAC(self, "isHighestBidder") <~ RACObserve(bidCheckingModel, "isHighestBidder")
         RAC(self, "reserveNotMet") <~ RACObserve(bidCheckingModel, "reserveNotMet")

--- a/Kiosk/Bid Fulfillment/Models/NewUser.swift
+++ b/Kiosk/Bid Fulfillment/Models/NewUser.swift
@@ -9,5 +9,7 @@
     dynamic var zipCode: String?
     dynamic var name: String?
 
+    dynamic var hasBeenRegistered: Bool = false
+
     var swipedCreditCard = false
 }

--- a/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
+++ b/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
@@ -1,0 +1,28 @@
+import Quick
+import Nimble
+import ReactiveCocoa
+//import Swift_RAC_Macros
+import Moya
+@testable
+import Kiosk
+
+class BidderNetworkModelTests: QuickSpec {
+    override func spec() {
+        var fulfillmentController: StubFulfillmentController!
+        var subject: BidderNetworkModel!
+
+        beforeEach {
+            fulfillmentController = StubFulfillmentController()
+            subject = BidderNetworkModel(fulfillmentController: fulfillmentController)
+        }
+
+        it("matches hasBeenRegistered is false") {
+            expect(subject.createdNewUser.first() as? Bool) == false
+        }
+
+        it("matches hasBeenRegistered is true") {
+            fulfillmentController.bidDetails.newUser.hasBeenRegistered = true
+            expect(subject.createdNewUser.first() as? Bool) == true
+        }
+    }
+}

--- a/KioskTests/Bid Fulfillment/LoadingViewModelTests.swift
+++ b/KioskTests/Bid Fulfillment/LoadingViewModelTests.swift
@@ -38,8 +38,9 @@ class LoadingViewModelTests: QuickSpec {
         }
 
         it("binds createdNewBidder") {
-            subject = LoadingViewModel(bidNetworkModel: StubBidderNetworkModel(), placingBid: true)
-            subject.bidderNetworkModel.createdNewBidder = true
+            let stubbedBidderNetworkModel = StubBidderNetworkModel()
+            subject = LoadingViewModel(bidNetworkModel: stubbedBidderNetworkModel, placingBid: true)
+            stubbedBidderNetworkModel.createdNewBidderSubject.sendNext(true)
 
             expect(subject.createdNewBidder) == true
         }
@@ -117,13 +118,19 @@ class LoadingViewModelTests: QuickSpec {
 let bidderID = "some-bidder-id"
 
 class StubBidderNetworkModel: BidderNetworkModel {
+    var createdNewBidderSubject = RACSubject()
+
     init() {
         super.init(fulfillmentController: StubFulfillmentController())
     }
 
     override func createOrGetBidder() -> RACSignal {
-        createdNewBidder = true
+        createdNewBidderSubject.sendNext(true)
         return RACSignal.empty()
+    }
+
+    override var createdNewUser: RACSignal {
+        return createdNewBidderSubject.startWith(false)
     }
 }
 

--- a/KioskTests/Bid Fulfillment/RegistrationPasswordViewModelTests.swift
+++ b/KioskTests/Bid Fulfillment/RegistrationPasswordViewModelTests.swift
@@ -40,7 +40,7 @@ class RegistrationPasswordViewModelTests: QuickSpec {
             }
         }
 
-        Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.empty())
+        Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.`return`(true))
     }
 
     func testSubject(passwordSubject: RACSignal = RACSignal.`return`(testPassword), invocationSignal: RACSignal = RACSubject(), finishedSubject: RACSubject = RACSubject()) -> RegistrationPasswordViewModel {

--- a/KioskTests/ListingsViewControllerTests.swift
+++ b/KioskTests/ListingsViewControllerTests.swift
@@ -94,11 +94,6 @@ class ListingsViewControllerTests: QuickSpec {
     }
 }
 
-let testSchedule = { (signal: RACSignal, scheduler: RACScheduler) -> RACSignal in
-    // Tricks the subject to thinking it's been scheduled on another queue
-    return signal
-}
-
 let listingsViewControllerTestsImage = UIImage.testImage(named: "artwork", ofType: "jpg")
 
 func testListingsViewController(storyboard: UIStoryboard = auctionStoryboard) -> ListingsViewController {

--- a/KioskTests/ListingsViewModelTests.swift
+++ b/KioskTests/ListingsViewModelTests.swift
@@ -5,6 +5,11 @@ import Moya
 @testable
 import Kiosk
 
+let testSchedule = { (signal: RACSignal, scheduler: RACScheduler) -> RACSignal in
+    // Tricks the subject to thinking it's been scheduled on another queue
+    return signal
+}
+
 class ListingsViewModelTests: QuickSpec {
     override func spec() {
         var subject: ListingsViewModel!
@@ -46,7 +51,7 @@ class ListingsViewModelTests: QuickSpec {
 
 
         it("paginates to the second page to retrieve all three sale artworks") {
-            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, pageSize: 2, logSync: { _ in})
+            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, pageSize: 2, logSync: { _ in}, schedule: testSchedule)
 
             kioskWaitUntil { done -> Void in
                 subject.updatedContentsSignal.take(1).subscribeCompleted {
@@ -58,7 +63,7 @@ class ListingsViewModelTests: QuickSpec {
         }
 
         it("updates with new values in existing sale artworks") {
-            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, syncInterval: 1, logSync: { _ in}, schedule: { signal, _ -> RACSignal in return signal })
+            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, syncInterval: 1, logSync: { _ in}, schedule: testSchedule)
 
             // Verify that initial value is correct
             waitUntil(timeout: 5) { done -> Void in
@@ -83,7 +88,7 @@ class ListingsViewModelTests: QuickSpec {
         }
 
         it("updates with new sale artworks when lengths differ") {
-            let subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, syncInterval: 1, logSync: { _ in}, schedule: { signal, _ -> RACSignal in return signal })
+            let subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, syncInterval: 1, logSync: { _ in}, schedule: testSchedule)
 
             saleArtworksCount = 2
 
@@ -121,7 +126,7 @@ class ListingsViewModelTests: QuickSpec {
 
             Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.empty())
 
-            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, pageSize: 4, syncInterval: 1, logSync: { _ in})
+            subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, pageSize: 4, syncInterval: 1, logSync: { _ in}, schedule: testSchedule)
 
             var initialFirstLotID: String?
             var subsequentFirstLotID: String?

--- a/KioskTests/ListingsViewModelTests.swift
+++ b/KioskTests/ListingsViewModelTests.swift
@@ -38,7 +38,7 @@ class ListingsViewModelTests: QuickSpec {
                 }
             }
 
-            Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.empty())
+            Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.`return`(true))
         }
 
         afterEach { () -> () in
@@ -124,7 +124,7 @@ class ListingsViewModelTests: QuickSpec {
                 }
             }
 
-            Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.empty())
+            Provider.sharedProvider = ArtsyProvider(endpointClosure: endpointsClosure, stubClosure: MoyaProvider.ImmediatelyStub, onlineSignal: RACSignal.`return`(true))
 
             subject = ListingsViewModel(selectedIndexSignal: RACSignal.`return`(0), showDetails: { _ in }, presentModal: { _ in }, pageSize: 4, syncInterval: 1, logSync: { _ in}, schedule: testSchedule)
 


### PR DESCRIPTION
If a new user is outbid, we allow them to increase their bid or "Continue" to view credentials. If they _did_ increase their bid, they'd never be shown those credentials because we were persisting the state of "newly registered" in a view model that never got forwarded. 

This should also address the CI issues we've been having – too many never-terminated recurring signals :sweat_smile: 