### PR TITLE
@orta: Uses bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ osx_image: xcode7
 language: objective-c
 
 cache:
-  - bundler
-  - cocoapods
+  directories:
+  - vendor/bundle
 
 env:
   global:


### PR DESCRIPTION
According [to the docs](http://docs.travis-ci.com/user/caching/), dependency caching doesn't work automatically if you specify a custom install step (which we do). So we need to specify the directory instead. 

I'm omitting CocoaPods caching because the cache is accessible to _all_ pull requests, and caching our Pods would cache our Keys, possibly exposing our API keys to a knowledgeable attacker.