### PR TITLE
@acjay: Discounts retracted single bids from sorting.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,5 @@
 upcoming:
+- Sale artworks with single, retracted bids will be sorted properly [ash]
 
 releases:
 - version: 3.8.5

--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -267,7 +267,16 @@ class ListingsViewModel: NSObject, ListingsViewModelType {
 // MARK: - Sorting Functions
 
 func leastBidsSort(lhs: SaleArtwork, _ rhs: SaleArtwork) -> Bool {
-    return (lhs.bidCount ?? 0) < (rhs.bidCount ?? 0)
+    switch (lhs.highestBidCents.hasValue, rhs.highestBidCents.hasValue) {
+    case (true, true): // Both valid, compare bidCount.
+        return (lhs.bidCount ?? 0) < (rhs.bidCount ?? 0)
+    case (true, _): // First valid, it comes first.
+        return true
+    case (_, true): // Second valid, it comes first.
+        return false
+    default: // Neither valid, doesn't matter.
+        return true
+    }
 }
 
 func mostBidsSort(lhs: SaleArtwork, _ rhs: SaleArtwork) -> Bool {


### PR DESCRIPTION
Replicates logic from here: https://github.com/artsy/eidolon/blob/49e798a272727869dabb71a0e4755891fb1c0679/Kiosk/App/Models/SaleArtworkViewModel.swift#L72-L75 I think we should move these into some sort of computed property on `SaleArtwork` or `SaleArtworkViewModel`, but this works for now. 

Fixes bug tracked in Trello: https://trello.com/c/E5faR3wq/169-kiosk-lots-that-had-bids-retracted-are-still-listed-under-highest-bids-as-if-they-still-have-a-bid