### PR TITLE
@acjay: Fixes Most Bids tab problem.

### DIFF
--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -280,7 +280,16 @@ func leastBidsSort(lhs: SaleArtwork, _ rhs: SaleArtwork) -> Bool {
 }
 
 func mostBidsSort(lhs: SaleArtwork, _ rhs: SaleArtwork) -> Bool {
-    return !leastBidsSort(lhs, rhs)
+    switch (lhs.highestBidCents.hasValue, rhs.highestBidCents.hasValue) {
+    case (true, true): // Both valid, compare bidCount.
+        return (lhs.bidCount ?? 0) > (rhs.bidCount ?? 0)
+    case (true, _): // First valid, it comes first.
+        return true
+    case (_, true): // Second valid, it comes first.
+        return false
+    default: // Neither valid, doesn't matter.
+        return true
+    }
 }
 
 func lowestCurrentBidSort(lhs: SaleArtwork, _ rhs: SaleArtwork) -> Bool {


### PR DESCRIPTION
The fixes in #545 missed a crucial problem: sorting by # of bids ascending and descending can no longer be done with the same sort function (negated, in one case). This was causing the bug to instead show up in the "Most Bids" tab.

<img width="926" alt="screen shot 2015-10-26 at 8 59 24 pm" src="https://cloud.githubusercontent.com/assets/498212/10746938/f689a3c6-7c25-11e5-95b3-b4e5884a9413.png">

I know this is getting ridiculous – I'll open an issue to abstract this properly later. 