### PR TITLE
@orta: Shores up analytics details

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,7 @@ upcoming:
 - iOS 9 support [ash]
 - Removes support for iOS 8 [ash]
 - Removes check for wifi network name [ash]
+- Improved analytics [ash]
 
 releases:
 - version: 3.8.6

--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+LongPressDisplayMessage.swift"; path = "Kiosk/UIView+LongPressDisplayMessage.swift"; sourceTree = SOURCE_ROOT; };
 		5E19E64E1A65630200F8CBDD /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		5E19E6511A656CCF00F8CBDD /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
+		5E3102ED1BF14E2500CA1823 /* CHANGELOG.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = CHANGELOG.yml; sourceTree = "<group>"; };
 		5E339E391A991899000C773D /* RACExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RACExtensions.swift; sourceTree = "<group>"; };
 		5E38FD2D1AF2154C00D30C17 /* RACExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RACExtensionsTests.swift; sourceTree = "<group>"; };
 		5E38FD2F1AF21ABA00D30C17 /* SwipeCreditCardViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeCreditCardViewControllerTests.swift; sourceTree = "<group>"; };
@@ -780,6 +781,7 @@
 		5EB0B6E41A5C3E6800B7CBF2 = {
 			isa = PBXGroup;
 			children = (
+				5E3102ED1BF14E2500CA1823 /* CHANGELOG.yml */,
 				5EB0B6EF1A5C3E6800B7CBF2 /* Kiosk */,
 				5EB0B7051A5C3E6800B7CBF2 /* KioskTests */,
 				5EB0B6EE1A5C3E6800B7CBF2 /* Products */,

--- a/Kiosk/App/AppViewController.swift
+++ b/Kiosk/App/AppViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import ARAnalytics
 import ReactiveCocoa
 
 class AppViewController: UIViewController, UINavigationControllerDelegate {

--- a/Kiosk/Auction Listings/ListingsViewController.swift
+++ b/Kiosk/Auction Listings/ListingsViewController.swift
@@ -171,12 +171,14 @@ extension ListingsViewController: UICollectionViewDataSource, UICollectionViewDe
 private extension ListingsViewController {
 
     func showDetailsForSaleArtwork(saleArtwork: SaleArtwork) {
+
+        ARAnalytics.event("Artwork Details Tapped", withProperties: ["id": saleArtwork.artwork.id])
         performSegueWithIdentifier(SegueIdentifier.ShowSaleArtworkDetails.rawValue, sender: saleArtwork)
     }
 
     func presentModalForSaleArtwork(saleArtwork: SaleArtwork) {
 
-        ARAnalytics.event("Bid Button Tapped")
+        ARAnalytics.event("Bid Button Tapped", withProperties: ["id": saleArtwork.artwork.id])
 
         let storyboard = UIStoryboard.fulfillment()
         let containerController = storyboard.instantiateInitialViewController() as! FulfillmentContainerViewController

--- a/Kiosk/Bid Fulfillment/LoadingViewController.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewController.swift
@@ -76,7 +76,7 @@ class LoadingViewController: UIViewController {
         logger.log("Bidding process result: reserveNotMet \(reserveNotMet), isHighestBidder \(isHighestBidder), bidIsResolved \(bidIsResolved), createdNewbidder \(createdNewBidder)")
 
         if placingBid {
-            ARAnalytics.event("Placed a bid", withProperties: ["top_bidder" : isHighestBidder])
+            ARAnalytics.event("Placed a bid", withProperties: ["top_bidder" : isHighestBidder, "sale_artwork": viewModel.bidDetails.saleArtwork?.artwork.id ?? ""])
 
             if bidIsResolved {
 

--- a/Kiosk/Bid Fulfillment/LoadingViewModel.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewModel.swift
@@ -46,7 +46,7 @@ class LoadingViewModel: NSObject {
             }
 
             if let strongSelf = self {
-                ARAnalytics.event("Started Placing Bid")
+                ARAnalytics.event("Started Placing Bid", withProperties: ["id": self?.bidDetails.saleArtwork?.artwork.id ?? ""])
                 return strongSelf.placeBidNetworkModel.bidSignal().ignore(nil)
             } else {
                 return RACSignal.empty()

--- a/Kiosk/UIViewController+Bidding.swift
+++ b/Kiosk/UIViewController+Bidding.swift
@@ -3,7 +3,7 @@ import ARAnalytics
 
 extension UIViewController {
     func bid(auctionID: String, saleArtwork: SaleArtwork, allowAnimations: Bool) {
-        ARAnalytics.event("Bid Button Tapped")
+        ARAnalytics.event("Bid Button Tapped", withProperties: ["id": saleArtwork.artwork.id])
         
         let storyboard = UIStoryboard.fulfillment()
         let containerController = storyboard.instantiateInitialViewController() as! FulfillmentContainerViewController


### PR DESCRIPTION
Adds more details to analytics events (like which artwork someone is interested in).

As requested on Trello: https://trello.com/c/P9cUr8Af/172-track-current-urls-artworks-for-bids-either-clicked-or-confirmed-in-kiosks-only-user-id-is-tracked