### PR TITLE
Tiny Typo: fix “wait unti” ➜ “wait until”.

### DIFF
--- a/Kiosk/App/Networking/Networking.swift
+++ b/Kiosk/App/Networking/Networking.swift
@@ -22,7 +22,7 @@ class OnlineProvider<Target where Target: TargetType>: RxMoyaProvider<Target> {
     override func request(token: Target) -> Observable<Moya.Response> {
         let actualRequest = super.request(token)
         return online
-            .ignore(false)  // Wait unti we're online
+            .ignore(false)  // Wait until we're online
             .take(1)        // Take 1 to make sure we only invoke the API once.
             .flatMap { _ in // Turn the online state into a network request
                 return actualRequest


### PR DESCRIPTION
Hey @ashfurrow and co, really enjoying watching [the code review](https://artsy.github.io/blog/2016/01/14/eidolon-code-review/)! Thanks for posting it, really interesting! :smiley:

Noticed a tiny typo.