### PR TITLE
Fix crash in Swift 2.2 compiler with Xcode 7.3

### DIFF
--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
@@ -83,10 +83,10 @@ class ManualCreditCardInputViewModel: NSObject {
 
         return stripeManager.registerCard(cardFullDigits.value, month: month, year: year, securityCode: securityCode.value, postalCode: billingZip.value).doOnNext { token in
 
-            newUser.creditCardName.value = token.card.name
-            newUser.creditCardType.value = token.card.brand.name
+            newUser.creditCardName.value = token.card!.name
+            newUser.creditCardType.value = token.card!.brand.name
             newUser.creditCardToken.value = token.tokenId
-            newUser.creditCardDigit.value = token.card.last4
+            newUser.creditCardDigit.value = token.card!.last4()
         }
     }
 

--- a/Kiosk/Bid Fulfillment/StripeManager.swift
+++ b/Kiosk/Bid Fulfillment/StripeManager.swift
@@ -21,10 +21,10 @@ class StripeManager: NSObject {
 
             me.stripeClient.createTokenWithCard(card) { (token, error) in
                 if (token as STPToken?).hasValue {
-                    observer.onNext(token)
+                    observer.onNext(token!)
                     observer.onCompleted()
                 } else {
-                    observer.onError(error)
+                    observer.onError(error!)
                 }
             }
 

--- a/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
+++ b/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
@@ -133,10 +133,10 @@ private extension SwipeCreditCardViewController {
 
                 self?.cardName.value = "Kiosk Staging CC Test"
                 self?.cardToken.value = token.tokenId
-                self?.cardLastDigits.value = token.card.last4
+                self?.cardLastDigits.value = token.card!.last4()
 
                 if let newUser = self?.navigationController?.fulfillmentNav().bidDetails.newUser {
-                    newUser.name.value = token.card.brand.name
+                    newUser.name.value = token.card!.brand.name
                 }
 
                 self?.finished.onCompleted()

--- a/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
+++ b/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
@@ -332,37 +332,37 @@ class SaleArtworkDetailsViewController: UIViewController {
         }
     }
 
+    private enum LabelType {
+        case Header
+        case Body
+    }
+
+    private func label(type: LabelType, layout: Observable<Void>? = nil) -> UILabel {
+        let (label, fontSize) = { () -> (UILabel, CGFloat) in
+            switch type {
+            case .Header:
+                return (ARSansSerifLabel(), 14)
+            case .Body:
+                return (ARSerifLabel(), 16)
+            }
+        }()
+
+        label.font = label.font.fontWithSize(fontSize)
+        label.lineBreakMode = .ByWordWrapping
+
+        layout?
+            .take(1)
+            .subscribeNext { [weak label] (_) in
+                if let label = label {
+                    label.preferredMaxLayoutWidth = CGRectGetWidth(label.frame)
+                }
+            }
+            .addDisposableTo(rx_disposeBag)
+
+        return label
+    }
+
     private func setupAdditionalDetailStackView() {
-        enum LabelType {
-            case Header
-            case Body
-        }
-
-        func label(type: LabelType, layout: Observable<Void>? = nil) -> UILabel {
-            let (label, fontSize) = { () -> (UILabel, CGFloat) in
-                switch type {
-                case .Header:
-                    return (ARSansSerifLabel(), 14)
-                case .Body:
-                    return (ARSerifLabel(), 16)
-                }
-            }()
-
-            label.font = label.font.fontWithSize(fontSize)
-            label.lineBreakMode = .ByWordWrapping
-
-            layout?
-                .take(1)
-                .subscribeNext { [weak label] (_) in
-                    if let label = label {
-                        label.preferredMaxLayoutWidth = CGRectGetWidth(label.frame)
-                    }
-                }
-                .addDisposableTo(rx_disposeBag)
-
-            return label
-        }
-
         additionalDetailScrollView.stackView.bottomMarginHeight = 40
 
         let imageView = UIImageView()
@@ -401,11 +401,11 @@ class SaleArtworkDetailsViewController: UIViewController {
                 .subscribeNext { [weak self] blurb in
                     guard let me = self else { return }
 
-                    let aboutArtistHeaderLabel = label(.Header)
+                    let aboutArtistHeaderLabel = me.label(.Header)
                     aboutArtistHeaderLabel.text = "About \(artist.name)"
                     me.additionalDetailScrollView.stackView.addSubview(aboutArtistHeaderLabel, withTopMargin: "22", sideMargin: "40")
 
-                    let aboutAristLabel = label(.Body, layout: me.layoutSubviews)
+                    let aboutAristLabel = me.label(.Body, layout: me.layoutSubviews)
                     aboutAristLabel.attributedText = MarkdownParser().attributedStringFromMarkdownString(blurb)
                     me.additionalDetailScrollView.stackView.addSubview(aboutAristLabel, withTopMargin: "22", sideMargin: "40")
                 }

--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ else
     pod 'Artsy+OSSUIFonts', '~> 1.1.0'
 end
 
-pod 'ORStackView'
+pod 'ORStackView', '2.0.0'
 pod 'FLKAutoLayout'
 pod 'ISO8601DateFormatter', '0.7'
 pod 'ARCollectionViewMasonryLayout', '~> 2.0.0'


### PR DESCRIPTION
Hi, In this code under SaleArtworkDetailsViewController.setupAdditionalDetailStackView:

```
if let artist = artist() {
            retrieveArtistBlurb()
                .filter { blurb in
                    return blurb.isNotEmpty
                }
                .subscribeNext { [weak self] blurb in
                    guard let me = self else { return }


                    let aboutArtistHeaderLabel = label(.Header)
```

The `subscribeNext` closure weakly references `self`, but also refers to the function `label` that strongly references `self` and causes Swift 2.2 to crash.

Other changes are just to get a clean build from zero. Not sure about ORStackView version required as I get a single large “help” button over the display.
