### PR TITLE
Ensure to add project name to cocoapods-keys command

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,10 +27,7 @@ lane :oss do
     'StripeProductionPublishableKey']
 
     commands = keys.map { |key|
-      command = "bundle exec pod keys set #{key} '-'"
-      if key == keys.first
-        command += " Eidolon"
-      end
+      command = "bundle exec pod keys set #{key} '-' Eidolon"
 
       command
     }.join(' ; ')


### PR DESCRIPTION
When I ran `fastlane oss`, it stopped after `ArtsyAPIClientSecret` is saved:

```sh
% be fastlane oss
[13:27:58]: -------------------------------------------------
[13:27:58]: --- Step: Verifying required fastlane version ---
[13:27:58]: -------------------------------------------------
[13:27:58]: fastlane version valid
[13:27:58]: Driving the lane 'oss' 🚀
[13:27:58]: -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------
[13:27:58]: --- Step: cd .. ; bundle exec pod keys set ArtsyAPIClientSecret '-' Eidolon ; bundle exec pod keys set ArtsyAPIClientKey '-' ; bundle exec pod keys set HockeyProductionSecret '-' ; bundle exec pod keys set HockeyBetaSecret
'-' ; bundle exec pod keys set MixpanelProductionAPIClientKey '-' ; bundle exec pod keys set MixpanelStagingAPIClientKey '-' ; bundle exec pod keys set CardflightStagingAPIClientKey '-' ; bundle exec pod keys set CardflightStagingMerch
antAccountToken '-' ; bundle exec pod keys set StripeStagingPublishableKey '-' ; bundle exec pod keys set CardflightProductionAPIClientKey '-' ; bundle exec pod keys set CardflightProductionMerchantAccountToken '-' ; bundle exec pod ke
ys set StripeProductionPublishableKey '-' ---
[13:27:58]: -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------
[13:27:58]: [SHELL COMMAND]: cd .. ; bundle exec pod keys set ArtsyAPIClientSecret '-' Eidolon ; bundle exec pod keys set ArtsyAPIClientKey '-' ; bundle exec pod keys set HockeyProductionSecret '-' ; bundle exec pod keys set HockeyBeta
Secret '-' ; bundle exec pod keys set MixpanelProductionAPIClientKey '-' ; bundle exec pod keys set MixpanelStagingAPIClientKey '-' ; bundle exec pod keys set CardflightStagingAPIClientKey '-' ; bundle exec pod keys set CardflightStagi
ngMerchantAccountToken '-' ; bundle exec pod keys set StripeStagingPublishableKey '-' ; bundle exec pod keys set CardflightProductionAPIClientKey '-' ; bundle exec pod keys set CardflightProductionMerchantAccountToken '-' ; bundle exec
 pod keys set StripeProductionPublishableKey '-'
[13:27:59]: [SHELL]: Saved ArtsyAPIClientSecret to Eidolon.
```

So I tried `pod keys` manually and found it waiting for user input:

```sh
% bundle exec pod keys set ArtsyAPIClientKey '-'
CocoaPods-Keys found too many Xcode projects (Kiosk.xcodeproj Demo.xcodeproj Pods.xcodeproj Terminal Notifier.xcodeproj). Please give a name for this project.
 >
```

Adding default project name to all commands solved this problem.

It might depend on the environment, but is there any reason you cannot set default project name to `pod keys` except for the first key (`ArtsyAPIClientSecret`)?
