### PR TITLE
Fixes bid resolution problems

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,6 @@
 upcoming:
+- Fixes problem placing bids [ash]
+- Fixes inability to cancel after agreeing to place a higher bid [ash]
 
 releases:
 - version: 5.0.1

--- a/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
+++ b/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
@@ -100,7 +100,7 @@ private extension BidderNetworkModel {
         // If the user was asked to swipe a card, we'd have stored the token. 
         // If the token is not there, then the user must already have one on file. So we can skip this step.
         guard let token = bidDetails.newUser.creditCardToken.value else {
-            return .empty()
+            return .just()
         }
 
         let swiped = bidDetails.newUser.swipedCreditCard
@@ -110,7 +110,7 @@ private extension BidderNetworkModel {
             .filterSuccessfulStatusCodes()
             .map(void)
             .doOnCompleted { [weak self] in
-                // Adding the credit card succeeded, so we shoudl clear the newUser.creditCardToken so that we don't
+                // Adding the credit card succeeded, so we should clear the newUser.creditCardToken so that we don't
                 // inadvertently try to re-add their card token if they need to increase their bid.
 
                 self?.bidDetails.newUser.creditCardToken.value = nil
@@ -125,7 +125,7 @@ private extension BidderNetworkModel {
 
         return bool.flatMap { exists -> Observable<Void> in
             if exists {
-                return .empty()
+                return .just()
             } else {
                 return self.registerToAuction(self.bidDetails.auctionID, provider: provider).then { [weak self] in self?.generateAPIN(provider) }
             }

--- a/Kiosk/Bid Fulfillment/LoadingViewController.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewController.swift
@@ -142,6 +142,7 @@ extension LoadingViewController {
 
         let title = reserveNotMet ? "NO, THANKS" : (createdNewBidder ? "CONTINUE" : "BACK TO AUCTION")
         backToAuctionButton.setTitle(title, forState: .Normal)
+        fulfillmentContainer()?.cancelButton.hidden = false
     }
 
     func handleRegistered() {

--- a/Kiosk/Bid Fulfillment/LoadingViewModel.swift
+++ b/Kiosk/Bid Fulfillment/LoadingViewModel.swift
@@ -67,6 +67,7 @@ class LoadingViewModel: NSObject, LoadingViewModelType {
                 guard let me = self else { return .empty() }
                 guard me.placingBid else {
                     ARAnalytics.event("Registered New User Only")
+                    // Skipping all further actions, since we're not placing a bid.
                     return .empty()
                 }
 

--- a/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
+++ b/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
@@ -29,7 +29,7 @@ class BidderNetworkModelTests: QuickSpec {
             expect(try! subject.createdNewUser.toBlocking().first()) == true
         }
 
-        fit("sends a value even if not adding a card") {
+        it("sends a value even if not adding a card") {
             waitUntil { done in
                 subject
                     .createOrGetBidder()

--- a/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
+++ b/KioskTests/Bid Fulfillment/BidderNetworkModelTests.swift
@@ -9,10 +9,15 @@ class BidderNetworkModelTests: QuickSpec {
     override func spec() {
         var bidDetails: BidDetails!
         var subject: BidderNetworkModel!
+        var disposeBag: DisposeBag!
 
         beforeEach {
             bidDetails = testBidDetails()
+            bidDetails.newUser.email.value = "asdf@asdf.asdf"
+            bidDetails.newUser.phoneNumber.value = "12345678"
+            bidDetails.newUser.zipCode.value = "10013"
             subject = BidderNetworkModel(provider: Networking.newStubbingNetworking(), bidDetails: bidDetails)
+            disposeBag = DisposeBag()
         }
 
         it("matches hasBeenRegistered is false") {
@@ -22,6 +27,17 @@ class BidderNetworkModelTests: QuickSpec {
         it("matches hasBeenRegistered is true") {
             bidDetails.newUser.hasBeenRegistered.value = true
             expect(try! subject.createdNewUser.toBlocking().first()) == true
+        }
+
+        fit("sends a value even if not adding a card") {
+            waitUntil { done in
+                subject
+                    .createOrGetBidder()
+                    .subscribeNext { _ in
+                        done()
+                    }
+                    .addDisposableTo(disposeBag)
+            }
         }
     }
 }


### PR DESCRIPTION
This is a fix for a problem tracked in Trello: https://trello.com/c/Bio2jZQe/297-kiosk-showstopper-bid-polling-for-resolving-high-bidder-status-failing#

The issue is that bids weren't being placed (unless you were also registering, strangely). Actually this makes sense, once the underlying issue was found. 

We were sending `empty()` as a result of "we don't need to do this piece of work", and then trying to `flatMap` that empty observable to the bid-placing network call. But empty observables don't have anything to `flatMap` against, they're empty. So instead, now we're sending `just()`, which is short for `just(Void())`, which is a value (an empty one). So that value can get `flatMap`'d appropriately.

tl;dr we were returning an empty observable instead of an observable that sends an empty value.

![](http://media4.giphy.com/media/zH2UJxZ0OPDxu/giphy.gif)

Also, I fixed a problem where if you placed a bid, but it wasn't high enough, and then you hit "place higher bid", then changed your mind, the cancel button was gone and the app wouldn't let you leave without placing a higher bid.