### PR TITLE
Workaround for tall image

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,5 @@
 upcoming:
+- Fixes display issue with D*Face artwork image [ash]
 
 releases:
 - version: 5.1.0

--- a/Kiosk/App/Models/Image.swift
+++ b/Kiosk/App/Models/Image.swift
@@ -60,10 +60,10 @@ final class Image: NSObject, JSONAbleType {
 
     func thumbnailURL() -> NSURL? {
         let preferredVersions = { () -> Array<String> in
-            // This is a hack for https://www.artsy.net/artwork/keith-winstein-qrpff
+            // This is a hack for https://www.artsy.net/artwork/d-star-face-work-on-paper-number-5
             // It's a very tall image and the "medium" version looks terribad.
-            // Will work on a more general-purpose, long-term solution with our designers.
-            if self.id == "5509bd3b7261692aeeb20500" {
+            // In the long-term, we have an issue to fix this for good: https://github.com/artsy/eidolon/issues/396
+            if self.id == "56ba2884139b211c61000204" {
                 return ["large", "larger"]
             } else {
                 return ["medium", "large", "larger"]


### PR DESCRIPTION
[This](https://www.artsy.net/artwork/d-star-face-work-on-paper-number-5) artwork is too tall, and throws off our masonry layout. This isn't the first time it's happened, so I repurposed the old hack, and updated with a link to how we plan to deal with this longterm. 

Before:

![img_0026](https://cloud.githubusercontent.com/assets/498212/13088093/e2e13ac8-d4b8-11e5-8f10-8b74046edbd4.PNG)

Notice how blurry it is. 

After:

![screen shot 2016-02-16 at 2 22 51 pm](https://cloud.githubusercontent.com/assets/498212/13088102/edb22bba-d4b8-11e5-9286-25317a325d07.png)

Much nicer. 