### PR TITLE
use experimental version of nimble

### DIFF
--- a/KioskTests/Bid Fulfillment/PlaceBidNetworkModelTests.swift
+++ b/KioskTests/Bid Fulfillment/PlaceBidNetworkModelTests.swift
@@ -77,9 +77,9 @@ class PlaceBidNetworkModelTests: QuickSpec {
                     }
                     .addDisposableTo(disposeBag)
             }
-
-            expect(auctionID) == fulfillmentController.bidDetails.saleArtwork?.auctionID
-            expect(artworkID) == fulfillmentController.bidDetails.saleArtwork?.artwork.id
+            
+            expect(auctionID) == (fulfillmentController.bidDetails.saleArtwork?.auctionID)!
+            expect(artworkID) == fulfillmentController.bidDetails.saleArtwork!.artwork.id
             expect(Int(bidCents!)) == Int(fulfillmentController.bidDetails.bidAmountCents.value ?? 0)
         }
 

--- a/KioskTests/ListingsViewModelTests.swift
+++ b/KioskTests/ListingsViewModelTests.swift
@@ -153,7 +153,7 @@ class ListingsViewModelTests: QuickSpec {
             expect(subsequentFirstLotID).toNot( beEmpty() )
 
             // Now that the IDs have changed, check that they're not equal.
-            expect(initialFirstLotID) != subsequentFirstLotID
+            expect(initialFirstLotID) != subsequentFirstLotID!
         }
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ pod 'Action'
 
 target 'KioskTests' do
 
-  pod 'FBSnapshotTestCase'
+  pod 'FBSnapshotTestCase', git: 'https://github.com/orta/ios-snapshot-test-case.git'
   pod 'Nimble-Snapshots'
   pod 'Quick'
   pod 'Nimble', :git => 'https://github.com/morganchen12/Nimble.git', :branch => 'nil-literal-compare'

--- a/Podfile
+++ b/Podfile
@@ -70,7 +70,7 @@ target 'KioskTests' do
   pod 'FBSnapshotTestCase'
   pod 'Nimble-Snapshots'
   pod 'Quick'
-  pod 'Nimble'
+  pod 'Nimble', :git => 'https://github.com/morganchen12/Nimble.git', :branch => 'nil-literal-compare'
   pod 'Forgeries'
   pod 'RxBlocking'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,10 +28,10 @@ PODS:
     - NJKWebViewProgress (~> 0.2)
   - ECPhoneNumberFormatter (0.1.1)
   - EDColor (0.4.0)
-  - FBSnapshotTestCase (2.0.7):
-    - FBSnapshotTestCase/SwiftSupport (= 2.0.7)
-  - FBSnapshotTestCase/Core (2.0.7)
-  - FBSnapshotTestCase/SwiftSupport (2.0.7):
+  - FBSnapshotTestCase (2.1.0):
+    - FBSnapshotTestCase/SwiftSupport (= 2.1.0)
+  - FBSnapshotTestCase/Core (2.1.0)
+  - FBSnapshotTestCase/SwiftSupport (2.1.0):
     - FBSnapshotTestCase/Core
   - FLKAutoLayout (0.1.1)
   - fmemopen (0.0.1)
@@ -49,8 +49,8 @@ PODS:
     - Moya/Core
     - RxSwift (= 2.0.0)
   - Nimble (4.0.1)
-  - Nimble-Snapshots (3.0.0):
-    - FBSnapshotTestCase (~> 2.0.7)
+  - Nimble-Snapshots (4.1.0):
+    - FBSnapshotTestCase (~> 2.0)
     - Nimble
     - Quick
   - NJKWebViewProgress (0.2.3):
@@ -96,7 +96,7 @@ DEPENDENCIES:
   - CardFlight
   - DZNWebViewController (from `https://github.com/orta/DZNWebViewController.git`)
   - ECPhoneNumberFormatter
-  - FBSnapshotTestCase
+  - FBSnapshotTestCase (from `https://github.com/orta/ios-snapshot-test-case.git`)
   - FLKAutoLayout
   - Forgeries
   - ISO8601DateFormatter (= 0.7)
@@ -124,6 +124,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/ashfurrow/ARTiledImageView.git
   DZNWebViewController:
     :git: https://github.com/orta/DZNWebViewController.git
+  FBSnapshotTestCase:
+    :git: https://github.com/orta/ios-snapshot-test-case.git
   Keys:
     :path: Pods/CocoaPodsKeys
   Nimble:
@@ -142,6 +144,9 @@ CHECKOUT OPTIONS:
   DZNWebViewController:
     :commit: 9121386901af95072fb19eaa3df7060ca46fc337
     :git: https://github.com/orta/DZNWebViewController.git
+  FBSnapshotTestCase:
+    :commit: 6b3e8978084388f9aae392fd1e0e21b1ddb88ae3
+    :git: https://github.com/orta/ios-snapshot-test-case.git
   Nimble:
     :commit: fa75bbf4507cacc5d5b33aa4e98ac2a9f3fee96d
     :git: https://github.com/morganchen12/Nimble.git
@@ -166,7 +171,7 @@ SPEC CHECKSUMS:
   DZNWebViewController: 54e8ee1c5bcc43e341ad77737631098d0d76db69
   ECPhoneNumberFormatter: 061041e7715f8d3f2e8e2a069ddf28c52f7bd314
   EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
-  FBSnapshotTestCase: 7e85180d0d141a0cf472352edda7e80d7eaeb547
+  FBSnapshotTestCase: 68c3221ddd3bf5bbe783c1015f8acc12c3768a4d
   FLKAutoLayout: 95b12c5cd9652100235140b68652f063f7437851
   fmemopen: dc31f7d3004644b33deee95e047305d23f8cfdd4
   Forgeries: ce03936ada2a8d33d3711d7bb7123be505b83430
@@ -176,7 +181,7 @@ SPEC CHECKSUMS:
   Mixpanel: fd52e097ae0d27295d0595b2261c60b94d191fda
   Moya: dfd9310f3dfb198927976dad445ead477ca6c2a3
   Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
-  Nimble-Snapshots: ab41dd737dcd33a0b0cb005a30465fef70b7207a
+  Nimble-Snapshots: 2da4d2ec829b458d6886c06812c52493fce284c9
   NJKWebViewProgress: f481fd424cb5ecc27eacae11b5397db92fba9a4d
   NSObject+Rx: 552d0a5bb78087b0faf9f8a066148577f1231426
   ORStackView: 5df6b1b990b0648d8ef6f69f89361ea8648e8f64

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,9 +13,9 @@ PODS:
   - ARCollectionViewMasonryLayout (2.0.0)
   - ARTiledImageView (1.2.0):
     - SDWebImage/Core
+  - Artsy+OSSUIFonts (1.1.0)
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
-  - Artsy+UIFonts (1.1.0)
   - Artsy+UILabels (1.3.1):
     - Artsy+UIColors
   - Artsy-UIButtons (1.4.0):
@@ -48,7 +48,7 @@ PODS:
   - Moya/RxSwift (5.3.0):
     - Moya/Core
     - RxSwift (= 2.0.0)
-  - Nimble (3.1.0)
+  - Nimble (4.0.1)
   - Nimble-Snapshots (3.0.0):
     - FBSnapshotTestCase (~> 2.0.7)
     - Nimble
@@ -89,8 +89,8 @@ DEPENDENCIES:
   - ARAnalytics/Mixpanel
   - ARCollectionViewMasonryLayout (~> 2.0.0)
   - ARTiledImageView (from `https://github.com/ashfurrow/ARTiledImageView.git`)
+  - Artsy+OSSUIFonts (~> 1.1.0)
   - Artsy+UIColors
-  - Artsy+UIFonts (~> 1.1.0)
   - Artsy+UILabels
   - Artsy-UIButtons
   - CardFlight
@@ -102,7 +102,7 @@ DEPENDENCIES:
   - ISO8601DateFormatter (= 0.7)
   - Keys (from `Pods/CocoaPodsKeys`)
   - Moya/RxSwift
-  - Nimble
+  - Nimble (from `https://github.com/morganchen12/Nimble.git`, branch `nil-literal-compare`)
   - Nimble-Snapshots
   - NSObject+Rx
   - ORStackView
@@ -126,6 +126,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/orta/DZNWebViewController.git
   Keys:
     :path: Pods/CocoaPodsKeys
+  Nimble:
+    :branch: nil-literal-compare
+    :git: https://github.com/morganchen12/Nimble.git
   Reachability:
     :branch: frameworks
     :git: https://github.com/ashfurrow/Reachability.git
@@ -139,6 +142,9 @@ CHECKOUT OPTIONS:
   DZNWebViewController:
     :commit: 9121386901af95072fb19eaa3df7060ca46fc337
     :git: https://github.com/orta/DZNWebViewController.git
+  Nimble:
+    :commit: fa75bbf4507cacc5d5b33aa4e98ac2a9f3fee96d
+    :git: https://github.com/morganchen12/Nimble.git
   Reachability:
     :commit: 6db8c29565c319f59174dd63e4b1ac5b471d133a
     :git: https://github.com/ashfurrow/Reachability.git
@@ -152,8 +158,8 @@ SPEC CHECKSUMS:
   ARAnalytics: 5468652928cee7100dd0e6b5162631409da37106
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
   ARTiledImageView: a747cff42142ca04d1dc5cee516186f10b6c0949
+  Artsy+OSSUIFonts: 4b01bb7451a35a877a055cefcdd92cffa2207781
   Artsy+UIColors: 7a4c987885a8d8da3e22672a3232761f929dd2b6
-  Artsy+UIFonts: c51bb3b5cbf9c1a5fe198b4385d49133c5c71f5a
   Artsy+UILabels: 43da757ee01bce8165ec83123eccccdf1fe8843c
   Artsy-UIButtons: 6f67de2a5285f18acb5d0e2919d1b17188acbc27
   CardFlight: c27f6b57053ff7ee1918fd8130af289eef97195e
@@ -169,7 +175,7 @@ SPEC CHECKSUMS:
   Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   Mixpanel: fd52e097ae0d27295d0595b2261c60b94d191fda
   Moya: dfd9310f3dfb198927976dad445ead477ca6c2a3
-  Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
+  Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
   Nimble-Snapshots: ab41dd737dcd33a0b0cb005a30465fef70b7207a
   NJKWebViewProgress: f481fd424cb5ecc27eacae11b5397db92fba9a4d
   NSObject+Rx: 552d0a5bb78087b0faf9f8a066148577f1231426


### PR DESCRIPTION
@ashfurrow volunteered Eidolon to test https://github.com/Quick/Nimble/pull/289, and I have ~~no life~~ indefinite free time so I've made this PR. Thanks Ash!

Tests fail to build locally because `FBSnapshotTestCase` doesn't support `StaticString` yet.

```swift
func assert(assertion: Bool, message: String, file: String, line: UInt) {
  if !assertion {
    XCTFail(message, file: file, line: line) // Cannot convert value of type 'String' to expected argument 'StaticString' 
  }
}
```