### PR TITLE
Changes typealias to associatedtype inside protocols

### DIFF
--- a/Kiosk/App/Networking/Networking.swift
+++ b/Kiosk/App/Networking/Networking.swift
@@ -32,7 +32,7 @@ class OnlineProvider<Target where Target: TargetType>: RxMoyaProvider<Target> {
 }
 
 protocol NetworkingType {
-    typealias T: TargetType, ArtsyAPIType
+    associatedtype T: TargetType, ArtsyAPIType
     var provider: OnlineProvider<T> { get }
 }
 

--- a/Kiosk/Observable+Operators.swift
+++ b/Kiosk/Observable+Operators.swift
@@ -28,7 +28,7 @@ extension Observable {
 }
 
 protocol OptionalType {
-    typealias Wrapped
+    associatedtype Wrapped
 
     var value: Wrapped? { get }
 }


### PR DESCRIPTION
`typealias` usage inside protocols is deprecated in Swift 2.2 and will be removed in Swift 3 according to [this proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md). `associatedtype` should be use instead.