### PR TITLE
Use TestAppDelegate to prevent normal app launch during testing

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B9F6AC41D9E230F00A44C26 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9F6AC31D9E230F00A44C26 /* main.swift */; };
+		3B9F6AC61D9E243C00A44C26 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9F6AC51D9E243C00A44C26 /* TestAppDelegate.swift */; };
 		3FCE6D8A07CA1FA29F4A37DC /* Pods_KioskTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC6D95F6020DA76AECC315F /* Pods_KioskTests.framework */; };
 		5E0A4E3E1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */; };
 		5E19E6501A6564B300F8CBDD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E19E64E1A65630200F8CBDD /* Logger.swift */; };
@@ -238,6 +240,8 @@
 
 /* Begin PBXFileReference section */
 		3AC6D95F6020DA76AECC315F /* Pods_KioskTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KioskTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B9F6AC31D9E230F00A44C26 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		3B9F6AC51D9E243C00A44C26 /* TestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		5E0A4E3D1B41C9C800CB2BEA /* UIView+LongPressDisplayMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+LongPressDisplayMessage.swift"; path = "Kiosk/UIView+LongPressDisplayMessage.swift"; sourceTree = SOURCE_ROOT; };
 		5E19E64E1A65630200F8CBDD /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		5E19E6511A656CCF00F8CBDD /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
@@ -506,6 +510,8 @@
 				5E860FF11A5C429C00456E41 /* Views */,
 				5EF71E791AE98F080069A266 /* STPCard+Validation.h */,
 				5EF71E7A1AE98F080069A266 /* STPCard+Validation.m */,
+				3B9F6AC31D9E230F00A44C26 /* main.swift */,
+				3B9F6AC51D9E243C00A44C26 /* TestAppDelegate.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1176,6 +1182,7 @@
 				5E86109F1A5C429C00456E41 /* YourBiddingDetailsViewController.swift in Sources */,
 				5EF71E7D1AE996F50069A266 /* SwiftExtensions.swift in Sources */,
 				5E8610991A5C429C00456E41 /* RegistrationEmailViewController.swift in Sources */,
+				3B9F6AC61D9E243C00A44C26 /* TestAppDelegate.swift in Sources */,
 				5E8610771A5C429C00456E41 /* SimulatorOnlyView.swift in Sources */,
 				5E8610941A5C429C00456E41 /* RegistrationCoordinator.swift in Sources */,
 				5E8610A51A5C429C00456E41 /* SaleArtworkZoomViewController.swift in Sources */,
@@ -1228,6 +1235,7 @@
 				5E86106E1A5C429C00456E41 /* NSErrorExtensions.swift in Sources */,
 				5E86108B1A5C429C00456E41 /* FulfillmentContainerViewController.swift in Sources */,
 				5E86109C1A5C429C00456E41 /* RegistrationPostalZipViewController.swift in Sources */,
+				3B9F6AC41D9E230F00A44C26 /* main.swift in Sources */,
 				5E86105C1A5C429C00456E41 /* Bid.swift in Sources */,
 				5E8610911A5C429C00456E41 /* ManualCreditCardInputViewController.swift in Sources */,
 				5E86104D1A5C429C00456E41 /* AdminPanelViewController.swift in Sources */,

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -5,7 +5,6 @@ import RxSwift
 import Keys
 import Stripe
 
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     let helpViewController = Variable<HelpViewController?>(nil)
@@ -26,10 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if StubResponses.stubResponses() {
             provider = Networking.newStubbingNetworking()
         }
-
-
-        // I couldn't figure how to swizzle this out like we do in objc.
-        if let _ = NSClassFromString("XCTest") { return true }
 
         // Clear possible old contents from cache and defaults. 
         let imageCache = SDImageCache.sharedImageCache()

--- a/Kiosk/App/TestAppDelegate.swift
+++ b/Kiosk/App/TestAppDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  TestAppDelegate.swift
+//  Kiosk
+//
+//  Created by Scott Hoyt on 9/29/16.
+//  Copyright © 2016 Artsy. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class TestAppDelegate : NSObject, UIApplicationDelegate { }

--- a/Kiosk/App/main.swift
+++ b/Kiosk/App/main.swift
@@ -1,0 +1,23 @@
+//
+//  main.swift
+//  Kiosk
+//
+//  Created by Scott Hoyt on 9/29/16.
+//  Copyright © 2016 Artsy. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+// Determine if we are testing by checking for XCTest injected bundle
+func isRunningTests() -> Bool {
+    let environment = NSProcessInfo.processInfo().environment
+    if let injectBundle = environment["XCInjectBundle"] {
+        return injectBundle.pathExtension == "xctest"
+    }
+    return false
+}
+
+let appDelegateClass: AnyClass = isRunningTests() ? TestAppDelegate.self : AppDelegate.self
+
+UIApplicationMain(Process.argc, Process.unsafeArgv, NSStringFromClass(UIApplication), NSStringFromClass(appDelegateClass))


### PR DESCRIPTION
When I was going through the Eidolon code looking for examples of Moya usage, I noticed the work around for preventing normal app launch while testing. I thought I would share the approach that I have used before. It's more code and more files, but I like that it gets any reference to `XCTest` out of `AppDelegate` and prevents `AppDelegate` from ever loading at all--so less risk of unintended side effects during testing. For these reasons, I think it is slightly more elegant. Unfortunately I was coding blind on this one because of Xcode 8 and a problem with `cocoapods-keys`, so I'm not 100% sure it even compiles 😬. But the idea is there if you want to use it at all. If not, no worries, the current solution is certainly more concise. Cheers!