### PR TITLE
Sale list crash fix

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,6 @@
 upcoming:
 - Underlying infrastructure work and library updates. [AYastrebov]
+- Fixes problem with the app crashing when switching auctions. [ash]
 
 releases:
 - version: 5.6.0

--- a/Kiosk/App/Models/Sale.swift
+++ b/Kiosk/App/Models/Sale.swift
@@ -5,14 +5,14 @@ final class Sale: NSObject, JSONAbleType {
     dynamic let id: String
     dynamic let isAuction: Bool
     dynamic let startDate: Date
-    dynamic let endDate: Date
+    dynamic let endDate: Date?
     dynamic let name: String
     dynamic var artworkCount: Int
     dynamic let auctionState: String
 
     dynamic var buyersPremium: BuyersPremium?
 
-    init(id: String, name: String, isAuction: Bool, startDate: Date, endDate: Date, artworkCount: Int, state: String) {
+    init(id: String, name: String, isAuction: Bool, startDate: Date, endDate: Date?, artworkCount: Int, state: String) {
         self.id = id
         self.name = name
         self.isAuction = isAuction
@@ -28,7 +28,7 @@ final class Sale: NSObject, JSONAbleType {
         let id = json["id"].stringValue
         let isAuction = json["is_auction"].boolValue
         let startDate = KioskDateFormatter.fromString(json["start_at"].stringValue)!
-        let endDate = KioskDateFormatter.fromString(json["end_at"].stringValue)!
+        let endDate = KioskDateFormatter.fromString(json["end_at"].stringValue)
         let name = json["name"].stringValue
         let artworkCount = json["eligible_sale_artworks_count"].intValue
         let state = json["auction_state"].stringValue
@@ -44,6 +44,11 @@ final class Sale: NSObject, JSONAbleType {
 
     func isActive(_ systemTime:SystemTime) -> Bool {
         let now = systemTime.date()
+        guard let endDate = endDate else {
+            // Live sales don't have end dates, and the kiosk isn't compatible with live sales.
+            // So we'll say any live sale is "not active"
+            return false
+        }
         return (now as NSDate).earlierDate(startDate) == startDate && (now as NSDate).laterDate(endDate) == endDate
     }
 }

--- a/Kiosk/Auction Listings/ListingsCountdownManager.swift
+++ b/Kiosk/Auction Listings/ListingsCountdownManager.swift
@@ -74,10 +74,10 @@ class ListingsCountdownManager: NSObject {
         guard time.inSync() else { return }
         guard sale.id != "" else { return }
 
-        if sale.isActive(time) {
+        if sale.isActive(time), let endDate = sale.endDate {
             let now = time.date()
 
-            let components = Calendar.current.dateComponents([.hour, .minute, .second], from: now, to: sale.endDate)
+            let components = Calendar.current.dateComponents([.hour, .minute, .second], from: now, to: endDate)
 
             self.countdownLabel.text = "\(formatter.string(from: (components.hour ?? 0) as NSNumber)!) : \(formatter.string(from: (components.minute ?? 0) as NSNumber)!) : \(formatter.string(from: (components.second ?? 0) as NSNumber)!)"
 

--- a/KioskTests/Models/SaleTests.swift
+++ b/KioskTests/Models/SaleTests.swift
@@ -23,7 +23,7 @@ class SaleTests: QuickSpec {
             expect(sale.id) == id
             expect(sale.isAuction) == isAuction
             expect(yearFromDate(sale.startDate)) == 2014
-            expect(yearFromDate(sale.endDate)) == 2015
+            expect(yearFromDate(sale.endDate!)) == 2015
             expect(sale.name) == name
         }
         


### PR DESCRIPTION
Live auctions (which the Kiosk doesn't support but does list) now have optional end dates. This fixes a crash when looking at the auction list in the Admin menu if there were a live sale listed there.