### PR TITLE
Fixes typos in docs/overview.md

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 ## App Structure
 
-The App is a Swift based RAC app. That means a reliance on functional programming. If any of this is new to you then it's recommended that you consult the books below. This means trying to wrap existing imperitive patterns in terms of streams and signals.
+The App is a Swift based RAC app. That means a reliance on functional programming. If any of this is new to you then it's recommended that you consult the books below. This means trying to wrap existing imperative patterns in terms of streams and signals.
 
 Unlike previous apps, this app aims to use Apples visual programming tools to reduce the actual code written as much as possible. If you are new to using Interface Builder and Storyboards I would recommend running though [this tutorial](http://www.raywenderlich.com/50308/storyboards-tutorial-in-ios-7-part-1) by Ray Wenderlich.
 
@@ -16,4 +16,4 @@ In order of accessibility / good learning order.
 
 ## Testing
 
-We're using [Quick / Nimble](https://github.com/Quick/), as they seem to be in the lead for BDD testing on Swift. The test target can be ran with `⌘ + u` on the Kiosk Target. Due to Swift's rather awkard class privacy settings make sure the target membership for classes being tested is in both Kiosk & KioskTests.
+We're using [Quick / Nimble](https://github.com/Quick/), as they seem to be in the lead for BDD testing on Swift. The test target can be ran with `⌘ + u` on the Kiosk Target. Due to Swift's rather awkward class privacy settings make sure the target membership for classes being tested is in both Kiosk & KioskTests.


### PR DESCRIPTION
`imperitive` -> `imperative`
`awkard` -> `awkward `