### PR TITLE
Defaults to unknown reader type, logging improvements.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,5 @@
 upcoming:
+- Fixed a problem with newer card readers. [ash]
 
 releases:
 - version: 5.7.1

--- a/Kiosk/Admin/AdminCardTestingViewController.swift
+++ b/Kiosk/Admin/AdminCardTestingViewController.swift
@@ -38,7 +38,7 @@ class AdminCardTestingViewController: UIViewController {
                         return
                     }
 
-                    let cardDetails = "Card: \(card.name) - \(card.last4) \n \(card.cardToken)"
+                    let cardDetails = "Card: \(card.name ?? "") - \(card.last4 ?? "") \n \(card.cardToken ?? "")"
                     self.log(cardDetails)
                 }
             }

--- a/Kiosk/App/CardHandler.swift
+++ b/Kiosk/App/CardHandler.swift
@@ -29,7 +29,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
     func startSearching() {
         sessionManager.setLogging(true)
 
-        reader = CFTReader(reader: CFTReaderType.UNKNOWN)
+        reader = CFTReader(reader: 0)
         reader.delegate = self
         reader.swipeHasTimeout(false)
         _cardStatus.onNext("Started searching")

--- a/Kiosk/App/CardHandler.swift
+++ b/Kiosk/App/CardHandler.swift
@@ -29,7 +29,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
     func startSearching() {
         sessionManager.setLogging(true)
 
-        reader = CFTReader(reader: CFTReaderType(rawValue: 1)!)
+        reader = CFTReader(reader: CFTReaderType.UNKNOWN)
         reader.delegate = self
         reader.swipeHasTimeout(false)
         _cardStatus.onNext("Started searching")
@@ -50,7 +50,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
                 logger.log("Card was tokenized")
 
             }, failure: { [weak self] (error) in
-                self?._cardStatus.onNext("Card Flight Error: \(error)");
+                self?._cardStatus.onNext("Card Flight Error: \(String(describing: error))");
                 logger.log("Card was not tokenizable")
             })
             
@@ -88,7 +88,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
     }
 
     func readerGenericResponse(_ cardData: String!) {
-        _cardStatus.onNext("Reader received non-card data: \(cardData) ");
+        _cardStatus.onNext("Reader received non-card data: \(cardData ?? "") ");
         reader.beginSwipe()
     }
 

--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,7 @@ target 'Kiosk' do
   pod 'ARAnalytics/Mixpanel'
   pod 'ARAnalytics/HockeyApp'
 
-  pod 'CardFlight'
+  pod 'CardFlight', '3.2.1'
   pod 'Stripe'
   pod 'ECPhoneNumberFormatter'
   pod 'UIImageViewAligned', :git => 'https://github.com/ashfurrow/UIImageViewAligned.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,9 @@ PODS:
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
     - UIView+BooleanAnimations
-  - CardFlight (3.5.1)
+  - CardFlight (3.2.1):
+    - CardFlight/AudioJack (= 3.2.1)
+  - CardFlight/AudioJack (3.2.1)
   - DZNWebViewController (2.0):
     - NJKWebViewProgress (~> 0.2)
   - ECPhoneNumberFormatter (0.1.1)
@@ -91,7 +93,7 @@ DEPENDENCIES:
   - Artsy+UIFonts
   - Artsy+UILabels
   - Artsy-UIButtons
-  - CardFlight
+  - CardFlight (= 3.2.1)
   - DZNWebViewController (from `https://github.com/orta/DZNWebViewController.git`)
   - ECPhoneNumberFormatter
   - FBSnapshotTestCase
@@ -143,7 +145,7 @@ SPEC CHECKSUMS:
   Artsy+UIFonts: 155b972733a24bb12f152fb6d25e2610c1cb93e0
   Artsy+UILabels: c5bef562052f74bc2f0d523c0f1a289c59c7fbed
   Artsy-UIButtons: 0c87d8a112e6b1d688b153c2a7a8f155e2f1a18f
-  CardFlight: e438f8c42d6636bc6ffe3312ecc9398b89e7aed4
+  CardFlight: cd86855c73cb99eb13e26ee40ef06775eada1965
   DZNWebViewController: 54e8ee1c5bcc43e341ad77737631098d0d76db69
   ECPhoneNumberFormatter: 061041e7715f8d3f2e8e2a069ddf28c52f7bd314
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
@@ -173,6 +175,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 07bca6bd5af15b2e2489501eef79ddf11fe0a1e1
+PODFILE CHECKSUM: 59dbc4471f38b262edd498257b2c8cfea835bc2b
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
Newer card readers weren't "connecting", so this changes it and adds a few other improvements. They're now reading the card, but not able to tokenize them. I've opened [an issue](https://github.com/CardFlight/cardflight-ios/issues/72) to ask for help.

Fixes https://github.com/artsy/eidolon/issues/658