### PR TITLE
Updates CardFlight SDK

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,6 @@
 upcoming:
 - Enables Segment analytics. [ash]
+- Updates CardFlight SDK. [ash]
 
 releases:
 - version: 5.8.3

--- a/Kiosk/App/CardHandler.swift
+++ b/Kiosk/App/CardHandler.swift
@@ -29,7 +29,7 @@ class CardHandler: NSObject, CFTReaderDelegate {
     func startSearching() {
         sessionManager.setLogging(true)
 
-        reader = CFTReader(reader: 0)
+        reader = CFTReader(reader: CFTReaderType.UNKNOWN)
         reader.delegate = self
         reader.swipeHasTimeout(false)
         _cardStatus.onNext("Started searching")

--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ target 'Kiosk' do
   pod 'ARAnalytics/Segmentio'
   pod 'ARAnalytics/HockeyApp'
 
-  pod 'CardFlight', '3.2.1'
+  pod 'CardFlight'
   pod 'Stripe'
   pod 'ECPhoneNumberFormatter'
   pod 'UIImageViewAligned', :git => 'https://github.com/ashfurrow/UIImageViewAligned.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,9 +23,7 @@ PODS:
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
     - UIView+BooleanAnimations
-  - CardFlight (3.2.1):
-    - CardFlight/AudioJack (= 3.2.1)
-  - CardFlight/AudioJack (3.2.1)
+  - CardFlight (3.6)
   - DZNWebViewController (2.0):
     - NJKWebViewProgress (~> 0.2)
   - ECPhoneNumberFormatter (0.1.1)
@@ -91,7 +89,7 @@ DEPENDENCIES:
   - Artsy+UIFonts
   - Artsy+UILabels
   - Artsy-UIButtons
-  - CardFlight (= 3.2.1)
+  - CardFlight
   - DZNWebViewController (from `https://github.com/orta/DZNWebViewController.git`)
   - ECPhoneNumberFormatter
   - FBSnapshotTestCase
@@ -150,7 +148,7 @@ SPEC CHECKSUMS:
   Artsy+UIFonts: 155b972733a24bb12f152fb6d25e2610c1cb93e0
   Artsy+UILabels: c5bef562052f74bc2f0d523c0f1a289c59c7fbed
   Artsy-UIButtons: 0c87d8a112e6b1d688b153c2a7a8f155e2f1a18f
-  CardFlight: cd86855c73cb99eb13e26ee40ef06775eada1965
+  CardFlight: 90ddf87380b682e1d961a93fe0869fc99416145c
   DZNWebViewController: 54e8ee1c5bcc43e341ad77737631098d0d76db69
   ECPhoneNumberFormatter: 061041e7715f8d3f2e8e2a069ddf28c52f7bd314
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
@@ -179,6 +177,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 6f3c965f062489bdf3952cbf147de85170f67a24
+PODFILE CHECKSUM: 0a5c7dfb255f05090568633982a8b17307d4fd2f
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
Version 3.6 fixes a problem with newer card readers, no reason we shouldn't be on the latest and greatest.