### PR TITLE
WIP: Migrates to Moya 9

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
 - Updates CardFlight SDK. Again. [ash]
 - Updates CocoaPods. [ash]
 - Updates Font pod. [ash]
+- Updates to latest head of Moya. [ash]
 
 releases:
 - version: 5.8.3

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -50,6 +50,10 @@ enum ArtsyAuthenticatedAPI {
 
 extension ArtsyAPI : TargetType, ArtsyAPIType {
 
+    var headers: [String : String]? {
+        return nil
+    }
+
     public var parameterEncoding: ParameterEncoding {
         return JSONEncoding.default
     }
@@ -252,6 +256,10 @@ extension ArtsyAPI : TargetType, ArtsyAPIType {
 }
 
 extension ArtsyAuthenticatedAPI: TargetType, ArtsyAPIType {
+
+    var headers: [String : String]? {
+        return nil
+    }
 
     public var parameterEncoding: ParameterEncoding {
         return JSONEncoding.default

--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,7 @@ target 'Kiosk' do
   pod 'SwiftyJSON'
   pod 'RxSwift'
   pod 'RxCocoa'
-  pod 'Moya/RxSwift'
+  pod 'Moya/RxSwift', git: 'https://github.com/Moya/Moya.git', branch: 'feature/rx_reactive'
   pod 'NSObject+Rx'
   pod 'Action'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Action (2.2.2):
     - RxCocoa (~> 3.0)
     - RxSwift (~> 3.0)
-  - Alamofire (4.4.0)
+  - Alamofire (4.5.0)
   - Analytics (3.6.0)
   - ARAnalytics/CoreIOS (4.0.1)
   - ARAnalytics/HockeyApp (4.0.1):
@@ -39,12 +39,12 @@ PODS:
   - HockeySDK-Source (4.1.5)
   - ISO8601DateFormatter (0.8)
   - Keys (1.0.0)
-  - Moya/Core (8.0.3):
+  - Moya/Core (8.0.5):
     - Alamofire (~> 4.1)
     - Result (~> 3.0)
-  - Moya/RxSwift (8.0.3):
+  - Moya/RxSwift (8.0.5):
     - Moya/Core
-    - RxSwift (~> 3.0)
+    - RxSwift (~> 3.3)
   - Nimble (6.0.1)
   - Nimble-Snapshots (4.4.0):
     - Nimble-Snapshots/Core (= 4.4.0)
@@ -63,12 +63,12 @@ PODS:
     - FLKAutoLayout (~> 0.1)
   - Quick (1.0.0)
   - ReachabilitySwift (3)
-  - Result (3.2.1)
+  - Result (3.2.3)
   - RxBlocking (3.1.0):
     - RxSwift (~> 3.1)
   - RxCocoa (3.1.0):
     - RxSwift (~> 3.1)
-  - RxSwift (3.1.0)
+  - RxSwift (3.5.0)
   - SDWebImage (3.8.2):
     - SDWebImage/Core (= 3.8.2)
   - SDWebImage/Core (3.8.2)
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - HockeySDK-Source (from `https://github.com/bitstadium/HockeySDK-iOS.git`)
   - ISO8601DateFormatter
   - Keys (from `Pods/CocoaPodsKeys`)
-  - Moya/RxSwift
+  - Moya/RxSwift (from `https://github.com/Moya/Moya.git`, branch `feature/rx_reactive`)
   - Nimble
   - Nimble-Snapshots
   - NSObject+Rx
@@ -123,6 +123,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/bitstadium/HockeySDK-iOS.git
   Keys:
     :path: Pods/CocoaPodsKeys
+  Moya:
+    :branch: feature/rx_reactive
+    :git: https://github.com/Moya/Moya.git
   UIImageViewAligned:
     :git: https://github.com/ashfurrow/UIImageViewAligned.git
 
@@ -133,13 +136,16 @@ CHECKOUT OPTIONS:
   HockeySDK-Source:
     :commit: 551ca733c29bd35dddb651d9661c8839de4e7985
     :git: https://github.com/bitstadium/HockeySDK-iOS.git
+  Moya:
+    :commit: a4ad787b8e1948121a9c2a50028a225e07636158
+    :git: https://github.com/Moya/Moya.git
   UIImageViewAligned:
     :commit: 6f8cb5669b219ef08c90c2e2e5a082cadfe7565b
     :git: https://github.com/ashfurrow/UIImageViewAligned.git
 
 SPEC CHECKSUMS:
   Action: 9a3d372fb15b057cce7d069a5e1ece8da12483d4
-  Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
+  Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
   Analytics: 15be3e651d22cc811f44df65698538236676437b
   ARAnalytics: 85e7bb999e2a40cea7d2394e71e8ecbafa50f2d0
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
@@ -157,7 +163,7 @@ SPEC CHECKSUMS:
   HockeySDK-Source: ab4eef2ac5c07c45db5844ae724bf6f06199b214
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
-  Moya: d3721622e3cc0cc2f038d69a258686f0b66e7252
+  Moya: 176333402d54951cb7e721878b8dc5adf812f1d6
   Nimble: 1527fd1bd2b4cf0636251a36bc8ab37e81da8347
   Nimble-Snapshots: e743439f26c2fa99d8f7e0d7c01c99bcb40aa6f2
   NJKWebViewProgress: f481fd424cb5ecc27eacae11b5397db92fba9a4d
@@ -165,10 +171,10 @@ SPEC CHECKSUMS:
   ORStackView: 5df6b1b990b0648d8ef6f69f89361ea8648e8f64
   Quick: 8024e4a47e6cc03a9d5245ef0948264fc6d27cff
   ReachabilitySwift: f5b9bb30a0777fac8f09ce8b067e32faeb29bb64
-  Result: 2453a22e5c5b11c0c3a478736e82cd02f763b781
+  Result: 128640a6347e8d2ae48b142556739a2d13f90ce6
   RxBlocking: cd73ef6a5f8c39cede9488178c46aa0c3c3ed17f
   RxCocoa: 50d7564866da9299161e86a263ce12a0873904d8
-  RxSwift: 83ff553e7593fdfdcb2562933a64c0284dffdadc
+  RxSwift: 18ee9d78b45edb3b0b7e79916b47a116e6dbc842
   SDWebImage: '098e97e6176540799c27e804c96653ee0833d13c'
   Stripe: 0f41a33a6fa3ac76ee668d7df3e2680c28b8ab1a
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
@@ -177,6 +183,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 0a5c7dfb255f05090568633982a8b17307d4fd2f
+PODFILE CHECKSUM: bbd944cce9c32f616f5fd7a60d855ce003e93d07
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
This PR points our Moya dependency to [this PR](https://github.com/Moya/Moya/pull/1153), a proposal in Moya to move to a more idiomatic way of accessing the Rx extension of Moya. I had some concerns about backwards compatibility and wanted to use Eidolon as a testbed to see how the migrate went.

Things went very smoothly. I had to add the `headers` property to my `TargetType`s incidentally. The actual change for the PR involves the `Networking.swift` file. These changes modify how we customize the Rx extensions in Moya; specifically, our subclass _has_ a provider now (instead of _being_ a provider before). There were a few gotchas with the compiler so hopefully this PR will help someone else.

This is a WIP since Moya 9 isn't officially out yet. 

Tests fail locally but this seems incidental to the Moya changes:

<img width="2402" alt="screen shot 2017-07-05 at 1 27 23 pm" src="https://user-images.githubusercontent.com/498212/27876609-bd50e4c4-6185-11e7-8a69-4e272227f6c6.png">
