### PR TITLE
Moves to RxOptional and cleans up RxSwift use

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,5 @@
 upcoming:
+- Moves to dependencies for common RxSwift operators. [ash]
 
 releases:
 - version: 5.9.0

--- a/Kiosk/App/AppDelegate+GlobalActions.swift
+++ b/Kiosk/App/AppDelegate+GlobalActions.swift
@@ -102,9 +102,9 @@ extension AppDelegate {
         let action = CocoaAction { input -> Observable<Void> in
             return retainedAction?
                 .execute(input)
-                .doOnCompleted {
+                .do(onCompleted: {
                     retainedAction = nil
-                } ?? Observable.just(Void())
+                }) ?? Observable.just(Void())
         }
 
         return action

--- a/Kiosk/App/BidderDetailsRetrieval.swift
+++ b/Kiosk/App/BidderDetailsRetrieval.swift
@@ -17,23 +17,22 @@ extension UIViewController {
     func retrieveBidderDetails(provider: Networking, email: String) -> Observable<Void> {
         return Observable.just(email)
             .take(1)
-            .doOnNext { _ in
+            .do(onNext: { _ in
                 SVProgressHUD.show()
-            }
+            })
             .flatMap { email -> Observable<Void> in
                 let endpoint = ArtsyAPI.bidderDetailsNotification(auctionID: appDelegate().appViewController.sale.value.id, identifier: email)
 
                 return provider.request(endpoint).filterSuccessfulStatusCodes().map(void)
             }
             .throttle(1, scheduler: MainScheduler.instance)
-            .doOnNext { _ in
+            .do(onNext: { _ in
                 SVProgressHUD.dismiss()
                 self.present(UIAlertController.successfulBidderDetailsAlertController(), animated: true, completion: nil)
-            }
-            .doOnError { _ in
+            }, onError: { _ in
                 SVProgressHUD.dismiss()
                 self.present(UIAlertController.failedBidderDetailsAlertController(), animated: true, completion: nil)
-            }
+            })
     }
 
     func emailPromptAlertController(provider: Networking) -> UIAlertController {

--- a/Kiosk/App/Models/SystemTime.swift
+++ b/Kiosk/App/Models/SystemTime.swift
@@ -12,7 +12,7 @@ class SystemTime {
         return provider.request(endpoint)
             .filterSuccessfulStatusCodes()
             .mapJSON()
-            .doOnNext { [weak self] response in
+            .do(onNext: { [weak self] response in
                 guard let dictionary = response as? NSDictionary else { return }
 
                 let timestamp: String = (dictionary["iso8601"] as? String) ?? ""
@@ -20,7 +20,9 @@ class SystemTime {
                     self?.systemTimeInterval = Date().timeIntervalSince(artsyDate)
                 }
 
-            }.logError().map(void)
+            })
+            .logError()
+            .map(void)
     }
 
     func inSync() -> Bool {

--- a/Kiosk/App/SwiftExtensions.swift
+++ b/Kiosk/App/SwiftExtensions.swift
@@ -1,3 +1,5 @@
+import RxOptional
+
 extension Optional {
     var hasValue: Bool {
         switch self {
@@ -19,27 +21,9 @@ extension String {
     }
 }
 
-// Anything that can hold a value (strings, arrays, etc)
-protocol Occupiable {
-    var isEmpty: Bool { get }
-    var isNotEmpty: Bool { get }
-}
-
-// Give a default implementation of isNotEmpty, so conformance only requires one implementation
-extension Occupiable {
-    var isNotEmpty: Bool {
-        return !isEmpty
-    }
-}
-
-extension String: Occupiable { }
-
-// I can't think of a way to combine these collection types. Suggestions welcome.
-extension Array: Occupiable { }
-extension Dictionary: Occupiable { }
-extension Set: Occupiable { }
 
 // Extend the idea of occupiability to optionals. Specifically, optionals wrapping occupiable things.
+// We're relying on the RxOptional pod to provide the Occupiable protocol.
 extension Optional where Wrapped: Occupiable {
     var isNilOrEmpty: Bool {
         switch self {
@@ -54,6 +38,7 @@ extension Optional where Wrapped: Occupiable {
         return !isNilOrEmpty
     }
 }
+
 
 extension NSNumber {
     var currencyValue: Currency {

--- a/Kiosk/Auction Listings/ListingsViewController.swift
+++ b/Kiosk/Auction Listings/ListingsViewController.swift
@@ -95,9 +95,9 @@ class ListingsViewController: UIViewController {
         viewModel
             .updatedContents
             .mapReplace(with: collectionView)
-            .doOnNext { collectionView in
+            .do(onNext: { collectionView in
                 collectionView.reloadData()
-            }
+            })
             .dispatchAsyncMainScheduler()
             .subscribe(onNext: { [weak self] collectionView in
                 // Make sure we're on screen and not in a test or something.

--- a/Kiosk/Auction Listings/ListingsViewModel.swift
+++ b/Kiosk/Auction Listings/ListingsViewModel.swift
@@ -179,7 +179,7 @@ class ListingsViewModel: NSObject, ListingsViewModelType {
 
 
         return recurring
-            .doOnNext(logSync)
+            .do(onNext: logSync)
             .flatMap { [weak self] _ in
                 return self?.allListingsRequest() ?? .empty()
             }

--- a/Kiosk/Bid Fulfillment/BidCheckingNetworkModel.swift
+++ b/Kiosk/Bid Fulfillment/BidCheckingNetworkModel.swift
@@ -55,18 +55,18 @@ class BidCheckingNetworkModel: NSObject, BidCheckingNetworkModelType {
 
                         return .just(Void())
                     }
-                    .doOnError { _ in
+                    .do(onError: { _ in
                         logger.log("Bidder position was processed but corresponding saleArtwork was not found")
-                    }
+                    })
                     .catchErrorJustReturn(Void())
                     .flatMap { _ -> Observable<Void> in
                         return self.checkForMaxBid(provider: provider)
                 }
-            } .doOnNext { _ in
+            }.do(onNext: { _ in
                 self.bidIsResolved.value = true
                 
                 // If polling fails, we can still show bid confirmation. Do not error.
-            }.catchErrorJustReturn()
+            }).catchErrorJustReturn()
     }
     
     fileprivate func poll(forUpdatedBidderPosition bidderPositionId: String, provider: AuthorizedNetworking) -> Observable<Void> {
@@ -105,14 +105,14 @@ class BidCheckingNetworkModel: NSObject, BidCheckingNetworkModelType {
 
     fileprivate func checkForMaxBid(provider: AuthorizedNetworking) -> Observable<Void> {
         return getMyBidderPositions(provider: provider)
-            .doOnNext{ newBidderPositions in
+            .do(onNext: { newBidderPositions in
 
                 if let topBidID = self.mostRecentSaleArtwork?.saleHighestBid?.id {
                     for position in newBidderPositions where position.highestBid?.id == topBidID {
                         self.isHighestBidder.value = true
                     }
                 }
-            }
+            })
             .map(void)
     }
 

--- a/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
+++ b/Kiosk/Bid Fulfillment/BidderNetworkModel.swift
@@ -74,12 +74,12 @@ private extension BidderNetworkModel {
         return provider.request(endpoint)
             .filterSuccessfulStatusCodes()
             .map(void)
-            .doOnError { error in
+            .do(onError: { error in
                 logger.log("Creating user failed.")
                 logger.log("Error: \((error as NSError).localizedDescription). \n \((error as NSError).artsyServerError())")
-        }.flatMap { _ -> Observable<AuthorizedNetworking> in
-            self.bidDetails.authenticatedNetworking(provider: self.provider)
-        }
+            }).flatMap { _ -> Observable<AuthorizedNetworking> in
+                self.bidDetails.authenticatedNetworking(provider: self.provider)
+            }
     }
 
     func updateUser() -> Observable<AuthorizedNetworking> {
@@ -109,12 +109,12 @@ private extension BidderNetworkModel {
         return provider.request(endpoint)
             .filterSuccessfulStatusCodes()
             .map(void)
-            .doOnCompleted { [weak self] in
+            .do(onCompleted: { [weak self] in
                 // Adding the credit card succeeded, so we should clear the newUser.creditCardToken so that we don't
                 // inadvertently try to re-add their card token if they need to increase their bid.
 
                 self?.bidDetails.newUser.creditCardToken.value = nil
-            }
+            })
             .logServerError(message: "Adding Card to User failed")
     }
 
@@ -160,10 +160,10 @@ private extension BidderNetworkModel {
             .mapTo(object: Bidder.self)
 
         return 
-            register.doOnNext{ [weak self] bidder in
+            register.do(onNext: { [weak self] bidder in
                 self?.bidDetails.bidderID.value = bidder.id
                 self?.bidDetails.newUser.hasBeenRegistered.value = true
-            }
+            })
             .logServerError(message: "Registering for Auction Failed.")
             .map(void)
     }
@@ -174,10 +174,10 @@ private extension BidderNetworkModel {
         return provider.request(endpoint)
             .filterSuccessfulStatusCodes()
             .mapJSON()
-            .doOnNext { [weak self] json in
+            .do(onNext: { [weak self] json in
                 let pin = (json as AnyObject)["pin"] as? String
                 self?.bidDetails.bidderPIN.value = pin
-            }
+            })
             .logServerError(message: "Generating a PIN for bidder has failed.")
             .map(void)
     }
@@ -188,9 +188,9 @@ private extension BidderNetworkModel {
             .filterSuccessfulStatusCodes()
             .mapJSON()
             .mapTo(object: User.self)
-            .doOnNext { [weak self] user in
+            .do(onNext: { [weak self] user in
                 self?.bidDetails.paddleNumber.value =  user.paddleNumber
-            }
+            })
             .logServerError(message: "Getting Bidder ID failed.")
             .map(void)
     }

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
@@ -66,7 +66,7 @@ class ConfirmYourBidArtsyLoginViewController: UIViewController {
                         .mapReplace(with: provider)
                 }.flatMap { provider -> Observable<Void> in
                     return me.creditCard(provider)
-                        .doOnNext { cards in
+                        .do(onNext: { cards in
                             guard let me = self else { return }
 
                             if cards.count > 0 {
@@ -74,14 +74,14 @@ class ConfirmYourBidArtsyLoginViewController: UIViewController {
                             } else {
                                 me.performSegue(.ArtsyUserHasNotRegisteredCard)
                             }
-                        }
+                        })
                         .map(void)
 
-                }.doOnError { [weak self] error in
+                }.do(onError: { [weak self] error in
                     logger.log("Error logging in: \((error as NSError).localizedDescription)")
                     logger.log("Error Logging in, likely bad auth creds, email = \(String(describing: self?.emailTextField.text))")
                     self?.showAuthenticationError()
-            }
+                })
         }
     }
 
@@ -128,9 +128,9 @@ class ConfirmYourBidArtsyLoginViewController: UIViewController {
 
             return self.provider.request(endpoint)
                 .filterSuccessfulStatusCodes()
-                .doOnNext { _ in
+                .do(onNext: { _ in
                     logger.log("Sent forgot password request")
-                }
+                })
                 .map(void)
         })
 

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidArtsyLoginViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Moya
 import RxSwift
+import RxOptional
 import Action
 
 class ConfirmYourBidArtsyLoginViewController: UIViewController {
@@ -49,8 +50,8 @@ class ConfirmYourBidArtsyLoginViewController: UIViewController {
             .bindTo(nav.bidDetails.newUser.password)
             .addDisposableTo(rx_disposeBag)
 
-        let inputIsEmail = emailText.asObservable().replaceNil(with: "").map(stringIsEmailAddress)
-        let passwordIsLongEnough = passwordText.asObservable().replaceNil(with: "").map(isZeroLength).not()
+        let inputIsEmail = emailText.asObservable().replaceNilWith("").map(stringIsEmailAddress)
+        let passwordIsLongEnough = passwordText.asObservable().replaceNilWith("").map(isZeroLength).not()
         let formIsValid = [inputIsEmail, passwordIsLongEnough].combineLatestAnd()
 
         let provider = self.provider
@@ -142,7 +143,7 @@ class ConfirmYourBidArtsyLoginViewController: UIViewController {
             textField
                 .rx.text
                 .asObservable()
-                .replaceNil(with: "")
+                .replaceNilWith("")
                 .bindTo(email)
                 .addDisposableTo(textField.rx_disposeBag)
 

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxOptional
 import Action
 
 class ConfirmYourBidEnterYourEmailViewController: UIViewController {
@@ -18,7 +19,7 @@ class ConfirmYourBidEnterYourEmailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let emailText = emailTextField.rx.textInput.text.asObservable().replaceNil(with: "")
+        let emailText = emailTextField.rx.textInput.text.asObservable().replaceNilWith("")
         let inputIsEmail = emailText.map(stringIsEmailAddress)
 
         let action = CocoaAction(enabledIf: inputIsEmail) { [weak self] _ in

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidEnterYourEmailViewController.swift
@@ -29,13 +29,12 @@ class ConfirmYourBidEnterYourEmailViewController: UIViewController {
 
             return self?.provider.request(endpoint)
                 .filter(statusCode: 200)
-                .doOnNext { _ in
+                .do(onNext: { _ in
                     me.performSegue(.ExistingArtsyUserFound)
-                }
-                .doOnError { error in
+                }, onError: { error in
 
                     self?.performSegue(.EmailNotFoundonArtsy)
-                }
+                })
                 .map(void) ?? .empty()
         }
 

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidPINViewController.swift
@@ -52,9 +52,9 @@ class ConfirmYourBidPINViewController: UIViewController {
             var loggedInProvider: AuthorizedNetworking!
 
             return bidDetails.authenticatedNetworking(provider: provider!)
-                .doOnNext { provider in
+                .do(onNext: { provider in
                     loggedInProvider = provider
-                }
+                })
                 .flatMap { provider -> Observable<AuthorizedNetworking> in
                     return provider
                         .request(ArtsyAuthenticatedAPI.me)
@@ -82,19 +82,19 @@ class ConfirmYourBidPINViewController: UIViewController {
                                 // We must check for a CC, and collect one if necessary.
                                 return me
                                     .checkForCreditCard(loggedInProvider: provider)
-                                    .doOnNext(me.got)
+                                    .do(onNext: me.got)
                                     .map(void)
                             }
                         }
                 }
-                .doOnError { error in
+                .do(onError: { error in
                     if let response = (error as? MoyaError)?.response {
                         let responseBody = NSString(data: response.data, encoding: String.Encoding.utf8.rawValue)
                         print("Error authenticating(\(response.statusCode)): \(String(describing: responseBody))")
                     }
 
                     me.showAuthenticationError()
-                }
+                })
         }
     }
 

--- a/Kiosk/Bid Fulfillment/ConfirmYourBidViewController.swift
+++ b/Kiosk/Bid Fulfillment/ConfirmYourBidViewController.swift
@@ -77,7 +77,7 @@ class ConfirmYourBidViewController: UIViewController {
             return me.provider.request(endpoint)
                 .filter(statusCode: 400)
                 .map(void)
-                .doOnError { error in
+                .do(onError: { error in
                     guard let me = self else { return }
 
                     // Due to AlamoFire restrictions we can't stop HTTP redirects
@@ -98,8 +98,7 @@ class ConfirmYourBidViewController: UIViewController {
                     } else {
                         me.performSegue(.ConfirmyourBidBidderNotFound)
                     }
-                }
-
+                })
         })
     }
 

--- a/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
+++ b/Kiosk/Bid Fulfillment/FulfillmentNavigationController.swift
@@ -40,7 +40,7 @@ class FulfillmentNavigationController: UINavigationController, FulfillmentContro
         let request = loggedInProvider.request(endpoint).filterSuccessfulStatusCodes().mapJSON().mapTo(object: User.self)
 
         return request
-            .doOnNext { [weak self] fullUser in
+            .do(onNext: { [weak self] fullUser in
                 guard let me = self else { return }
 
                 me.user = fullUser
@@ -51,7 +51,7 @@ class FulfillmentNavigationController: UINavigationController, FulfillmentContro
                 newUser.phoneNumber.value = me.user.phoneNumber
                 newUser.zipCode.value = me.user.location?.postalCode
                 newUser.name.value = me.user.name
-            }
+            })
             .logError(prefix: "error, the authentication for admin is likely wrong: ")
             .map(void)
     }

--- a/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
+++ b/Kiosk/Bid Fulfillment/ManualCreditCardInputViewModel.swift
@@ -59,9 +59,9 @@ class ManualCreditCardInputViewModel: NSObject {
                 return .empty()
             }
 
-            return me.registerCard(newUser: newUser).doOnCompleted {
+            return me.registerCard(newUser: newUser).do(onCompleted: {
                 me.finishedSubject?.onCompleted()
-            }.map(void)
+            }).map(void)
         }
 
     }
@@ -81,13 +81,13 @@ class ManualCreditCardInputViewModel: NSObject {
         let month = expirationMonth.value.toUInt(withDefault: 0)
         let year = expirationYear.value.toUInt(withDefault: 0)
 
-        return stripeManager.registerCard(digits: cardFullDigits.value, month: month, year: year, securityCode: securityCode.value, postalCode: billingZip.value).doOnNext { token in
+        return stripeManager.registerCard(digits: cardFullDigits.value, month: month, year: year, securityCode: securityCode.value, postalCode: billingZip.value).do(onNext: { token in
 
             newUser.creditCardName.value = token.card?.name
             newUser.creditCardType.value = token.card?.brand.name
             newUser.creditCardToken.value = token.tokenId
             newUser.creditCardDigit.value = token.card?.last4()
-        }
+        })
     }
 
     // Only set for testing purposes, otherwise ignore.

--- a/Kiosk/Bid Fulfillment/RegistrationEmailViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegistrationEmailViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RxSwift
+import RxOptional
 
 class RegistrationEmailViewController: UIViewController, RegistrationSubController, UITextFieldDelegate {
 
@@ -8,7 +9,7 @@ class RegistrationEmailViewController: UIViewController, RegistrationSubControll
     var finished = PublishSubject<Void>()
 
     lazy var viewModel: GenericFormValidationViewModel = {
-        let emailIsValid = self.emailTextField.rx.textInput.text.asObservable().replaceNil(with: "").map(stringIsEmailAddress)
+        let emailIsValid = self.emailTextField.rx.textInput.text.asObservable().replaceNilWith("").map(stringIsEmailAddress)
         return GenericFormValidationViewModel(isValid: emailIsValid, manualInvocation: self.emailTextField.rx_returnKey, finishedSubject: self.finished)
     }()
 

--- a/Kiosk/Bid Fulfillment/RegistrationMobileViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegistrationMobileViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RxSwift
+import RxOptional
 
 class RegistrationMobileViewController: UIViewController, RegistrationSubController, UITextFieldDelegate {
     
@@ -8,7 +9,7 @@ class RegistrationMobileViewController: UIViewController, RegistrationSubControl
     let finished = PublishSubject<Void>()
 
     lazy var viewModel: GenericFormValidationViewModel = {
-        let numberIsValid = self.numberTextField.rx.text.asObservable().replaceNil(with: "").map(isZeroLength).not()
+        let numberIsValid = self.numberTextField.rx.text.asObservable().replaceNilWith("").map(isZeroLength).not()
         return GenericFormValidationViewModel(isValid: numberIsValid, manualInvocation: self.numberTextField.rx_returnKey, finishedSubject: self.finished)
     }()
 

--- a/Kiosk/Bid Fulfillment/RegistrationPasswordViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegistrationPasswordViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RxSwift
+import RxOptional
 import Moya
 import Action
 
@@ -24,7 +25,7 @@ class RegistrationPasswordViewController: UIViewController, RegistrationSubContr
 
         return RegistrationPasswordViewModel(
             provider: self.provider,
-            password: self.passwordTextField.rx.text.asObservable().replaceNil(with: ""),
+            password: self.passwordTextField.rx.text.asObservable().replaceNilWith(""),
             execute: self.passwordTextField.rx_returnKey,
             completed: self.finished,
             email: email)

--- a/Kiosk/Bid Fulfillment/RegistrationPasswordViewModel.swift
+++ b/Kiosk/Bid Fulfillment/RegistrationPasswordViewModel.swift
@@ -55,9 +55,9 @@ class RegistrationPasswordViewModel: RegistrationPasswordViewModelType {
                         return .just(Void())
                     }
                 }
-                .doOnCompleted {
+                .do(onCompleted: {
                     completed.onCompleted()
-                }
+                })
         }
 
         self.action = action
@@ -74,8 +74,8 @@ class RegistrationPasswordViewModel: RegistrationPasswordViewModelType {
         return provider.request(endpoint)
             .filterSuccessfulStatusCodes()
             .map(void)
-            .doOnNext { _ in
+            .do(onNext: { _ in
                 logger.log("Sent forgot password request")
-            }
+            })
     }
 }

--- a/Kiosk/Bid Fulfillment/RegistrationPostalZipViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegistrationPostalZipViewController.swift
@@ -1,4 +1,5 @@
 import RxSwift
+import RxOptional
 
 class RegistrationPostalZipViewController: UIViewController, RegistrationSubController {
     @IBOutlet var zipCodeTextField: TextField!
@@ -6,7 +7,7 @@ class RegistrationPostalZipViewController: UIViewController, RegistrationSubCont
     let finished = PublishSubject<Void>()
 
     lazy var viewModel: GenericFormValidationViewModel = {
-        let zipCodeIsValid = self.zipCodeTextField.rx.text.asObservable().replaceNil(with: "").map(isZeroLength).not()
+        let zipCodeIsValid = self.zipCodeTextField.rx.text.asObservable().replaceNilWith("").map(isZeroLength).not()
         return GenericFormValidationViewModel(isValid: zipCodeIsValid, manualInvocation: self.zipCodeTextField.rx_returnKey, finishedSubject: self.finished)
     }()
 

--- a/Kiosk/Bid Fulfillment/YourBiddingDetailsViewController.swift
+++ b/Kiosk/Bid Fulfillment/YourBiddingDetailsViewController.swift
@@ -3,6 +3,7 @@ import Artsy_UILabels
 import Artsy_UIButtons
 import RxCocoa
 import RxSwift
+import RxOptional
 
 class YourBiddingDetailsViewController: UIViewController {
 

--- a/Kiosk/ListingsCollectionViewCell.swift
+++ b/Kiosk/ListingsCollectionViewCell.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Artsy_UILabels
 import RxSwift
+import RxOptional
 import RxCocoa
 import NSObject_Rx
 
@@ -89,7 +90,7 @@ class ListingsCollectionViewCell: UICollectionViewCell {
 
         // Start with things not expected to ever change. 
         viewModel.flatMapTo(SaleArtworkViewModel.lotLabel)
-            .replaceNil(with: "")
+            .replaceNilWith("")
             .mapToOptional()
             .bindTo(lotNumberLabel.rx.text)
             .addDisposableTo(reuseBag)

--- a/Kiosk/Observable+Operators.swift
+++ b/Kiosk/Observable+Operators.swift
@@ -27,27 +27,6 @@ extension Observable {
     }
 }
 
-// TODO: Move to do(onNext), etc, in RxSwift 3.
-extension Observable {
-    func doOnNext(_ closure: @escaping (Element) -> Void) -> Observable<Element> {
-        return self.do(onNext: { (element) in
-            closure(element)
-        })
-    }
-
-    func doOnCompleted(_ closure: @escaping () -> Void) -> Observable<Element> {
-        return self.do(onCompleted: {
-            closure()
-        })
-    }
-
-    func doOnError(_ closure: @escaping (Error) -> Void) -> Observable<Element> {
-        return self.do(onError: { (error) in
-            closure(error)
-        })
-    }
-}
-
 private let backgroundScheduler = SerialDispatchQueueScheduler(qos: .default)
 
 extension Observable {

--- a/Kiosk/Observable+Operators.swift
+++ b/Kiosk/Observable+Operators.swift
@@ -27,47 +27,7 @@ extension Observable {
     }
 }
 
-protocol OptionalType {
-    associatedtype Wrapped
-
-    var value: Wrapped? { get }
-}
-
-extension Optional: OptionalType {
-    var value: Wrapped? {
-        return self
-    }
-}
-
-extension Observable where Element: OptionalType {
-    func filterNil() -> Observable<Element.Wrapped> {
-        return flatMap { (element) -> Observable<Element.Wrapped> in
-            if let value = element.value {
-                return .just(value)
-            } else {
-                return .empty()
-            }
-        }
-    }
-
-    func filterNilKeepOptional() -> Observable<Element> {
-        return self.filter { (element) -> Bool in
-            return element.value != nil
-        }
-    }
-
-    func replaceNil(with nilValue: Element.Wrapped) -> Observable<Element.Wrapped> {
-        return flatMap { (element) -> Observable<Element.Wrapped> in
-            if let value = element.value {
-                return .just(value)
-            } else {
-                return .just(nilValue)
-            }
-        }
-    }
-}
-
-// TODO: Added in new RxSwift?
+// TODO: Move to do(onNext), etc, in RxSwift 3.
 extension Observable {
     func doOnNext(_ closure: @escaping (Element) -> Void) -> Observable<Element> {
         return self.do(onNext: { (element) in

--- a/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
+++ b/Kiosk/Sale Artwork Details/SaleArtworkDetailsViewController.swift
@@ -437,9 +437,9 @@ class SaleArtworkDetailsViewController: UIViewController {
                     return (json as AnyObject)["image_rights"] as? String
                 }
                 .filterNil()
-                .doOnNext { imageRights in
+                .do(onNext: { imageRights in
                     artwork.imageRights = imageRights
-                }
+                })
         }
     }
 
@@ -453,9 +453,9 @@ class SaleArtworkDetailsViewController: UIViewController {
                     return (json as AnyObject)["additional_information"] as? String
                 }
                 .filterNil()
-                .doOnNext{ info in
+                .do(onNext: { info in
                     artwork.additionalInfo = info
-                }
+                })
         }
     }
 
@@ -475,9 +475,9 @@ class SaleArtworkDetailsViewController: UIViewController {
                     return (json as AnyObject)["blurb"] as? String
                 }
                 .filterNil()
-                .doOnNext{ blurb in
+                .do(onNext: { blurb in
                     artist.blurb = blurb
-                }
+                })
         }
     }
 }

--- a/KioskTests/App/SwiftExtensionsTests.swift
+++ b/KioskTests/App/SwiftExtensionsTests.swift
@@ -1,6 +1,7 @@
 import Quick
 import Nimble
 import RxSwift
+import RxOptional
 
 @testable
 import Kiosk

--- a/KioskTests/ListingsViewControllerTests.swift
+++ b/KioskTests/ListingsViewControllerTests.swift
@@ -19,39 +19,44 @@ class ListingsViewControllerConfiguration: QuickConfiguration {
                 subject.loadViewProgrammatically()
             }
 
+            /*
+            Note that we use a tolerance of 1% to account for antialiasing issues that differ
+            from machine to machine.
+            */
+
             it("grid") {
                 subject.switchView[0]?.sendActions(for: .touchUpInside)
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
             
             it("least bids") {
                 subject.switchView[1]?.sendActions(for: .touchUpInside)
                 viewModel._gridSelected.value = false
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
 
             it("most bids") {
                 subject.switchView[2]?.sendActions(for: .touchUpInside)
                 viewModel._gridSelected.value = false
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
 
             it("highest bid") {
                 subject.switchView[3]?.sendActions(for: .touchUpInside)
                 viewModel._gridSelected.value = false
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
 
             it("lowest bid") {
                 subject.switchView[4]?.sendActions(for: .touchUpInside)
                 viewModel._gridSelected.value = false
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
 
             it("alphabetical") {
                 subject.switchView[5]?.sendActions(for: .touchUpInside)
                 viewModel._gridSelected.value = false
-                expect(subject).to( haveValidSnapshot(usesDrawRect: true) )
+                expect(subject).to( haveValidSnapshot(usesDrawRect: true, tolerance: 0.01) )
             }
         }
     }

--- a/Podfile
+++ b/Podfile
@@ -64,6 +64,7 @@ target 'Kiosk' do
   pod 'SwiftyJSON'
   pod 'RxSwift'
   pod 'RxCocoa'
+  pod 'RxOptional'
   pod 'Moya/RxSwift'
   pod 'NSObject+Rx'
   pod 'Action'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,6 +72,9 @@ PODS:
     - Nimble (~> 6.0)
     - RxBlocking (~> 3.0)
     - RxSwift (~> 3.0)
+  - RxOptional (3.2.0):
+    - RxCocoa
+    - RxSwift
   - RxSwift (3.1.0)
   - SDWebImage (3.8.2):
     - SDWebImage/Core (= 3.8.2)
@@ -112,6 +115,7 @@ DEPENDENCIES:
   - RxBlocking
   - RxCocoa
   - RxNimble
+  - RxOptional
   - RxSwift
   - SDWebImage (~> 3.7)
   - Stripe
@@ -174,6 +178,7 @@ SPEC CHECKSUMS:
   RxBlocking: cd73ef6a5f8c39cede9488178c46aa0c3c3ed17f
   RxCocoa: 50d7564866da9299161e86a263ce12a0873904d8
   RxNimble: 50a9da5852b298b2ec632cb00b79fa20be9f31b8
+  RxOptional: d2d6a68064bc16b4801332c40663967f481b0234
   RxSwift: 83ff553e7593fdfdcb2562933a64c0284dffdadc
   SDWebImage: '098e97e6176540799c27e804c96653ee0833d13c'
   Stripe: 0f41a33a6fa3ac76ee668d7df3e2680c28b8ab1a
@@ -183,6 +188,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: b8b41c512b6c47804dc56fcd2417472abc3cf3f0
+PODFILE CHECKSUM: df9251168a54b50f97a66fb3e48399dfc0a08ab7
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
This fixes #587 by moving our own functions to a pod that already contains them (Eidolon was the inspiration for the pod) and also cleans up our use of RxSwift. Specifically, it removes the custom `doOnNext`, `doOnError`, and `doOnCompleted` functions and replaces their use with the standard `do(onNext:onError:onCompleted:)` operator. Finally, it fixes some intermittently failing snapshot tests (see note left in file). 