### PR TITLE
Cleanup from RxSwift+Moya upgrades 📱

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,6 @@
 upcoming:
 - Moves to dependencies for common RxSwift operators. [ash]
+- Fixes parameter encoding bug. [ash]
 
 releases:
 - version: 5.9.0

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -56,9 +56,8 @@ extension ArtsyAPI : TargetType, ArtsyAPIType {
 
     var task: Task {
         let encoding: ParameterEncoding
-        switch self {
-        case .lostPasswordNotification,
-             .createUser:
+        switch self.method {
+        case .post:
             encoding = JSONEncoding.default
         default:
             encoding = URLEncoding.default
@@ -271,11 +270,8 @@ extension ArtsyAuthenticatedAPI: TargetType, ArtsyAPIType {
     var task: Task {
         let requestParameters = parameters ?? [:]
         let encoding: ParameterEncoding
-        switch self {
-        case .placeABid,
-             .registerCard,
-             .registerToBid,
-             .createPINForBidder:
+        switch self.method {
+        case .post:
             encoding = JSONEncoding.default
         default:
             encoding = URLEncoding.default

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -55,8 +55,16 @@ extension ArtsyAPI : TargetType, ArtsyAPIType {
     }
 
     var task: Task {
+        let encoding: ParameterEncoding
+        switch self {
+        case .lostPasswordNotification,
+             .createUser:
+            encoding = JSONEncoding.default
+        default:
+            encoding = URLEncoding.default
+        }
         if let requestParameters = parameters {
-            return .requestParameters(parameters: requestParameters, encoding: URLEncoding.default)
+            return .requestParameters(parameters: requestParameters, encoding: encoding)
         }
         return .requestPlain
     }
@@ -261,10 +269,18 @@ extension ArtsyAuthenticatedAPI: TargetType, ArtsyAPIType {
     }
 
     var task: Task {
-        if let requestParameters = parameters {
-            return .requestParameters(parameters: requestParameters, encoding: JSONEncoding.default)
+        let requestParameters = parameters ?? [:]
+        let encoding: ParameterEncoding
+        switch self {
+        case .placeABid,
+             .registerCard,
+             .registerToBid,
+             .createPINForBidder:
+            encoding = JSONEncoding.default
+        default:
+            encoding = URLEncoding.default
         }
-        return .requestPlain
+        return .requestParameters(parameters: requestParameters, encoding: encoding)
     }
 
     var path: String {

--- a/Kiosk/App/Networking/ArtsyAPI.swift
+++ b/Kiosk/App/Networking/ArtsyAPI.swift
@@ -56,7 +56,7 @@ extension ArtsyAPI : TargetType, ArtsyAPIType {
 
     var task: Task {
         if let requestParameters = parameters {
-            return .requestParameters(parameters: requestParameters, encoding: JSONEncoding.default)
+            return .requestParameters(parameters: requestParameters, encoding: URLEncoding.default)
         }
         return .requestPlain
     }

--- a/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
+++ b/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
@@ -34,11 +34,14 @@ enum RegistrationIndex {
 
 class RegistrationCoordinator: NSObject {
 
-    let currentIndex = Variable(0)
+    fileprivate let _currentIndex = Variable(0)
+    var currentIndex: Observable<Int> {
+        return _currentIndex.asObservable().distinctUntilChanged()
+    }
     var storyboard: UIStoryboard!
 
     func viewControllerForIndex(_ index: RegistrationIndex) -> UIViewController {
-        currentIndex.value = index.toInt()
+        _currentIndex.value = index.toInt()
         
         switch index {
 

--- a/Kiosk/Bid Fulfillment/RegisterViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegisterViewController.swift
@@ -33,35 +33,20 @@ class RegisterViewController: UIViewController {
         super.viewDidLoad()
 
         coordinator.storyboard = self.storyboard!
-        let registerIndex = coordinator.currentIndex.asObservable()
-        let indexIsConfirmed = registerIndex.map { return ($0 == RegistrationIndex.confirmVC.toInt()) }
+        let indexIsConfirmed = coordinator.currentIndex.map { return ($0 == RegistrationIndex.confirmVC.toInt()) }
 
         indexIsConfirmed
             .not()
             .bindTo(confirmButton.rx_hidden)
             .addDisposableTo(rx_disposeBag)
 
-        registerIndex
+        coordinator.currentIndex
             .bindTo(flowView.highlightedIndex)
             .addDisposableTo(rx_disposeBag)
 
         let details = self.fulfillmentNav().bidDetails
         flowView.details = details
         bidDetailsPreviewView.bidDetails = details
-
-        flowView
-            .highlightedIndex
-            .asObservable()
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] (index) in
-                if let _ = self?.fulfillmentNav() {
-                    let registrationIndex = RegistrationIndex.fromInt(index)
-
-                    let nextVC = self?.coordinator.viewControllerForIndex(registrationIndex)
-                    self?.goToViewController(nextVC!)
-                }
-            })
-            .addDisposableTo(rx_disposeBag)
 
         goToNextVC()
     }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,14 +14,14 @@ PODS:
   - ARCollectionViewMasonryLayout (2.0.0)
   - ARTiledImageView (1.1.1):
     - SDWebImage
-  - Artsy+OSSUIFonts (2.0.2)
   - Artsy+UIColors (3.1.0)
+  - Artsy+UIFonts (3.1.1)
   - Artsy+UILabels (2.1.2):
-    - Artsy+OSSUIFonts
     - Artsy+UIColors (~> 3.0)
+    - Artsy+UIFonts
   - Artsy-UIButtons (2.0.3):
-    - Artsy+OSSUIFonts
     - Artsy+UIColors (~> 3.0)
+    - Artsy+UIFonts
     - UIView+BooleanAnimations
   - CardFlight (3.6.1)
   - DZNWebViewController (2.0):
@@ -92,8 +92,8 @@ DEPENDENCIES:
   - ARAnalytics/Segmentio
   - ARCollectionViewMasonryLayout (~> 2.0.0)
   - ARTiledImageView
-  - Artsy+OSSUIFonts
   - Artsy+UIColors
+  - Artsy+UIFonts
   - Artsy+UILabels
   - Artsy-UIButtons
   - CardFlight
@@ -153,8 +153,8 @@ SPEC CHECKSUMS:
   ARAnalytics: 85e7bb999e2a40cea7d2394e71e8ecbafa50f2d0
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116
   ARTiledImageView: 8c6fd11d9e8459a853d94394adea3a5e8c9329ba
-  Artsy+OSSUIFonts: 10b588a6bcef1129959f9002266f1bc0c939be18
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
+  Artsy+UIFonts: e66afb5c40100e2fc5bba28feb7487e252f2d06f
   Artsy+UILabels: c5bef562052f74bc2f0d523c0f1a289c59c7fbed
   Artsy-UIButtons: 0c87d8a112e6b1d688b153c2a7a8f155e2f1a18f
   CardFlight: 7b34237b6098c231d7a0066c3e38610ca3a98112


### PR DESCRIPTION
Funny story! There's been a longstanding bug somewhere, which I will try to track down, but this fixes it. Eidolon has been specifying JSON encoding of request parameters for some time, but has been URL encoding them for GET/PUT requests (we only want JSON encoding for POST bodies). Somewhere, probably in Alamofire, the behaviour changed so if you specify JSON encoding, it _always_ encodes a HTTP body with JSON, even for GET requests. This confuses our API, so I've changed it to use JSON only for POST requests. This was a tricky one to track down – using the built-in `NetworkLoggerPlugin` with cURL printing helped a lot.

Additionally, there was a cycle in RxSwift where a Variable was being set inside a subscribe block that executes when the Variable changes. Kind of a weird one, not sure if that's a longstanding bug or something that changed in RxSwift, but the new diagnostic logging helped me track it down 👍

Finally, in the transition to Moya 9, some parameters had [accidentally been added as HTTP header fields](https://github.com/artsy/eidolon/pull/677/files#diff-319cda9244d4aefd8caec7cc37a529c3R42) which broke authenticated requests. Since Moya moved to a new Task infrastructure, augmenting parameters with new ones was a bit tricky.

This is still a WIP because I need to do more testing.