### PR TITLE
Removes Xcode 8 / Swift 3 specifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ Getting Started
 ---------------
 
 Now that we have the code [downloaded](#downloading-the-code), we can run the
-app using [Xcode 8](https://developer.apple.com/xcode/download/). Make sure to
+app using [Xcode 9](https://developer.apple.com/xcode/download/). Make sure to
 open the `Kiosk.xcworkspace` workspace, and not the `Kiosk.xcodeproj` project.
-Currently, the project is compatible with Xcode 8 and later only, as it's Swift 3.
 
 Artsy has licensed fonts for use in this app, but due to the terms of that
 license, they are not available for open source distribution. This has [required](http://artsy.github.io/blog/2014/06/20/artsys-first-closed-source-pod/)


### PR DESCRIPTION
Forgot to do this in #685 😅 