### PR TITLE
Fixes CardFlight integration

### DIFF
--- a/Kiosk.xcodeproj/project.pbxproj
+++ b/Kiosk.xcodeproj/project.pbxproj
@@ -1151,7 +1151,6 @@
 				"${BUILT_PRODUCTS_DIR}/Artsy+UIFonts/Artsy_UIFonts.framework",
 				"${BUILT_PRODUCTS_DIR}/Artsy+UILabels/Artsy_UILabels.framework",
 				"${BUILT_PRODUCTS_DIR}/Artsy-UIButtons/Artsy_UIButtons.framework",
-				"${PODS_ROOT}/CardFlight-v4/CardFlight.framework",
 				"${BUILT_PRODUCTS_DIR}/DZNWebViewController/DZNWebViewController.framework",
 				"${BUILT_PRODUCTS_DIR}/ECPhoneNumberFormatter/ECPhoneNumberFormatter.framework",
 				"${BUILT_PRODUCTS_DIR}/FLKAutoLayout/FLKAutoLayout.framework",
@@ -1187,7 +1186,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Artsy_UIFonts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Artsy_UILabels.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Artsy_UIButtons.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardFlight.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DZNWebViewController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ECPhoneNumberFormatter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLKAutoLayout.framework",
@@ -1553,7 +1551,6 @@
 					"$(SRCROOT)/Pods/CardFlight/**",
 				);
 				INFOPLIST_FILE = "Kiosk/Supporting Files/Info.plist";
-				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.kiosk.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kiosk/Supporting Files/BridgingHeader.h";

--- a/Kiosk/Admin/AdminCardTestingViewController.swift
+++ b/Kiosk/Admin/AdminCardTestingViewController.swift
@@ -38,21 +38,19 @@ class AdminCardTestingViewController: UIViewController {
                         return
                     }
 
-                    let cardDetails = "Card: \(card.cardInfo.cardholderName ?? "") - \(card.cardInfo.lastFour ?? "") \n \(card.token)"
+                    let cardDetails = "Card: \(card.name ?? "") - \(card.last4 ?? "") \n \(card.cardToken ?? "")"
                     self.log(cardDetails)
                 }
             }
             .disposed(by: rx.disposeBag)
+
+
+        cardHandler.startSearching()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         cardHandler.end()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        cardHandler.startSearching()
     }
 
     func log(_ string: String) {

--- a/Kiosk/App/AppDelegate.swift
+++ b/Kiosk/App/AppDelegate.swift
@@ -4,6 +4,7 @@ import SDWebImage
 import RxSwift
 import Keys
 import Stripe
+import MediaPlayer
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -64,6 +65,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         logger.log("App Started")
         ARAnalytics.event("Session Started")
+
+        // CardFlight v3 has a problem displaying the volume HUD (from a background thread, I think it confuses iOS).
+        // However, we can't upgrade to v4 yet. See for more info: https://artsyproduct.atlassian.net/browse/PURCHASE-615
+        let volumeView = MPVolumeView(frame: .zero)
+        volumeView.clipsToBounds = true
+        window?.addSubview(volumeView)
+
         return true
     }
 

--- a/Kiosk/App/CardHandler.swift
+++ b/Kiosk/App/CardHandler.swift
@@ -1,43 +1,21 @@
 import UIKit
 import RxSwift
-import CardFlight
 
-class CardHandler: NSObject, CFTTransactionDelegate {
+class CardHandler: NSObject, CFTReaderDelegate {
 
-    private let _cardStatus = PublishSubject<String>()
-    private let _userMessages = PublishSubject<String>()
-    private var cardReader: CFTCardReaderInfo?
-
-    var transaction: CFTTransaction?
+    fileprivate let _cardStatus = PublishSubject<String>()
 
     var cardStatus: Observable<String> {
         return _cardStatus.asObservable()
     }
 
-    var userMessages: Observable<String> {
-        // User messages are things like "Swipe card", "processing", or "Swipe card again". Due to a problem with the
-        // CardFlight SDK, the user is prompted to accept processing for card tokenization, which is provides a
-        // unfriendly user experience (prompting to accept a transaction that we're not actually placing). So we
-        // auto-accept these requests and filter out confirmation messages, which don't apply to tokenization flows,
-        // until this issue is fixed: https://github.com/CardFlight/cardflight-v4-ios/issues/4
-        return _userMessages
-            .asObservable()
-            .filter { message -> Bool in
-                !message.hasSuffix("?")
-            }
-    }
-
-    var cardFlightCredentials: CFTCredentials {
-        let credentials = CFTCredentials()
-        credentials.setup(apiKey: self.APIKey, accountToken: self.APIToken, completion: nil)
-        return credentials
-    }
-
-    var card: (cardInfo: CFTCardInfo, token: String)?
-
-
+    var card: CFTCard?
+    
     let APIKey: String
     let APIToken: String
+
+    var reader: CFTReader!
+    lazy var sessionManager = CFTSessionManager.sharedInstance()!
 
     init(apiKey: String, accountToken: String){
         APIKey = apiKey
@@ -45,137 +23,85 @@ class CardHandler: NSObject, CFTTransactionDelegate {
 
         super.init()
 
-        self.transaction = CFTTransaction(delegate: self)
-    }
-
-    deinit {
-        self.end()
+        sessionManager.setApiToken(APIKey, accountToken: APIToken, completed: nil)
     }
 
     func startSearching() {
-        _cardStatus.onNext("Starting search...")
-        let tokenizationParameters = CFTTokenizationParameters(customerId: nil, credentials: self.cardFlightCredentials)
-        self.transaction?.beginTokenizing(tokenizationParameters: tokenizationParameters)
+        sessionManager.setLogging(true)
+
+        reader = CFTReader(reader: CFTReaderType.UNKNOWN)
+        reader.delegate = self
+        reader.swipeHasTimeout(false)
+        _cardStatus.onNext("Started searching")
     }
 
     func end() {
-        transaction?.select(processOption: CFTProcessOption.abort)
-        transaction = nil
+        reader.cancelTransaction()
+        reader = nil
     }
 
-    func transaction(_ transaction: CFTTransaction, didUpdate state: CFTTransactionState, error: Error?) {
-        switch state {
-        case .completed:
-            _cardStatus.onNext("Transaction completed")
-        case .processing:
-            _cardStatus.onNext("Transaction processing")
-        case .deferred:
-            _cardStatus.onNext("Transaction deferred")
-        case .pendingCardInput:
-            _cardStatus.onNext("Pending card input")
-            transaction.select(cardReaderInfo: cardReader, cardReaderModel: cardReader?.cardReaderModel ?? .unknown)
-        case .pendingTransactionParameters:
-            _cardStatus.onNext("Pending transaction parameters")
-        case .unknown:
-            _cardStatus.onNext("Unknown transactionstate")
-        case .pendingProcessOption:
-            break
-        }
-    }
-
-    func transaction(_ transaction: CFTTransaction, didComplete historicalTransaction: CFTHistoricalTransaction) {
-        if let cardInfo = historicalTransaction.cardInfo, let token = historicalTransaction.cardToken {
-            self.card = (cardInfo: cardInfo, token: token)
+    func readerCardResponse(_ card: CFTCard?, withError error: Error?) {
+        if let card = card {
+            self.card = card;
             _cardStatus.onNext("Got Card")
-            _cardStatus.onCompleted()
+
+            card.tokenizeCard(success: { [weak self] in
+                self?._cardStatus.onCompleted()
+                logger.log("Card was tokenized")
+
+            }, failure: { [weak self] (error) in
+                self?._cardStatus.onNext("Card Flight Error: \(String(describing: error))");
+                logger.log("Card was not tokenizable")
+            })
+            
+        } else if let error = error {
+            self._cardStatus.onNext("response Error \(error)");
+            logger.log("CardReader got a response it cannot handle")
+
+
+            reader.beginSwipe();
+        }
+    }
+
+    func transactionResult(_ charge: CFTCharge!, withError error: Error!) {
+        logger.log("Unexcepted call to transactionResult callback: \(charge)\n\(error)")
+    }
+
+    // handle other delegate call backs with the status messages
+
+    func readerIsAttached() {
+        _cardStatus.onNext("Reader is attatched");
+    }
+
+    func readerIsConnecting() {
+        _cardStatus.onNext("Reader is connecting");
+    }
+
+    func readerIsDisconnected() {
+        _cardStatus.onNext("Reader is disconnected");
+        logger.log("Card Reader Disconnected")
+    }
+
+    func readerSwipeDidCancel() {
+        _cardStatus.onNext("Reader did cancel");
+        logger.log("Card Reader was Cancelled")
+    }
+
+    func readerGenericResponse(_ cardData: String!) {
+        _cardStatus.onNext("Reader received non-card data: \(cardData ?? "") ");
+        reader.beginSwipe()
+    }
+
+    func readerIsConnected(_ isConnected: Bool, withError error: Error!) {
+        if isConnected {
+            _cardStatus.onNext("Reader is connected")
+            reader.beginSwipe()
         } else {
-            _cardStatus.onNext("Card Flight Error – could not retrieve card data.");
-            if let error = historicalTransaction.error {
-                _cardStatus.onNext("response Error \(error)");
-                logger.log("CardReader got a response it cannot handle")
+            if (error != nil) {
+                _cardStatus.onNext("Reader is disconnected: \(error.localizedDescription)");
+            } else {
+                _cardStatus.onNext("Reader is disconnected");
             }
-            startSearching()
-        }
-    }
-
-    func transaction(_ transaction: CFTTransaction, didReceive cardReaderEvent: CFTCardReaderEvent, cardReaderInfo: CFTCardReaderInfo?) {
-        _cardStatus.onNext(cardReaderEvent.statusMessage)
-    }
-
-    func transaction(_ transaction: CFTTransaction, didUpdate cardReaderArray: [CFTCardReaderInfo]) {
-        self.cardReader = cardReaderArray.first
-        _cardStatus.onNext("Received new card reader availability, number of readers: \(cardReaderArray.count)")
-    }
-
-    func transaction(_ transaction: CFTTransaction, didRequestProcessOption cardInfo: CFTCardInfo) {
-        logger.log("Received request for processing option, will process transaction.")
-        _cardStatus.onNext("Request for process option, automatically processing...")
-        // We auto-accept the process option on the user's behalf because the prompt doesn't make sense in a
-        // tokenization flow. See comments in `userMessages` property above.
-        transaction.select(processOption: .process)
-    }
-
-    func transaction(_ transaction: CFTTransaction, didRequestDisplay message: CFTMessage) {
-        let message = message.primary ?? message.secondary ?? ""
-        _userMessages.onNext(message)
-        logger.log("Received request to display message: \(message)")
-        _cardStatus.onNext("Received message for user: \(message)")
-    }
-}
-
-typealias UnhandledDelegateCallbacks = CardHandler
-/// We don't expect any of these functions to be called, but they are required for the delegate protocol.
-extension UnhandledDelegateCallbacks {
-    func transaction(_ transaction: CFTTransaction, didDefer transactionData: Data) {
-        logger.log("Transaction has been deferred.")
-        _cardStatus.onNext("Transaction deferred")
-    }
-
-    public func transaction(_ transaction: CFTTransaction, didRequest cvm: CFTCVM) {
-        if cvm == CFTCVM.signature {
-            logger.log("Transaction requested signature from user, which should not occur for tokenization.")
-            _cardStatus.onNext("Ignoring user signature request from CardFlight")
-        }
-    }
-}
-
-extension CFTCardReaderEvent {
-    var statusMessage: String {
-        switch self {
-        case .unknown:
-            return "Unknown card event"
-        case .disconnected:
-            return "Reader is disconnected"
-        case .connected:
-            return "Reader is connected"
-        case .connectionErrored:
-            return "Connection error occurred"
-        case .cardSwiped:
-            return "Card swiped"
-        case .cardSwipeErrored:
-            return "Card swipe error"
-        case .cardInserted:
-            return "Card inserted"
-        case .cardInsertErrored:
-            return "Card insertion error"
-        case .cardRemoved:
-            return "Card removed"
-        case .cardTapped:
-            return "Card tapped"
-        case .cardTapErrored:
-            return "Card tap error"
-        case .updateStarted:
-            return "Update started"
-        case .updateCompleted:
-            return "Updated completed"
-        case .audioRecordingPermissionNotGranted:
-            return "iOS audio permissions no granted"
-        case .fatalError:
-            return "Fatal error"
-        case .connecting:
-            return "Connecting"
-        case .batteryStatusUpdated:
-            return "Battery status updated"
         }
     }
 }

--- a/Kiosk/App/GlobalFunctions.swift
+++ b/Kiosk/App/GlobalFunctions.swift
@@ -36,7 +36,7 @@ func responseIsOK(_ response: Response) -> Bool {
 
 func detectDevelopmentEnvironment() -> Bool {
     var developmentEnvironment = false
-    #if DEBUG || (arch(i386) || arch(x86_64))
+    #if DEBUG || (arch(i386) || arch(x86_64)) && os(iOS)
         developmentEnvironment = true
     #endif
     return developmentEnvironment

--- a/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
+++ b/Kiosk/Bid Fulfillment/SwipeCreditCardViewController.swift
@@ -9,10 +9,11 @@ class SwipeCreditCardViewController: UIViewController, RegistrationSubController
     @IBOutlet var cardStatusLabel: ARSerifLabel!
     let finished = PublishSubject<Void>()
 
-    @IBOutlet weak var titleLabel: ARSerifLabel!
     @IBOutlet weak var spinner: Spinner!
+    @IBOutlet weak var processingLabel: UILabel!
     @IBOutlet weak var illustrationImageView: UIImageView!
 
+    @IBOutlet weak var titleLabel: ARSerifLabel!
 
     class func instantiateFromStoryboard(_ storyboard: UIStoryboard) -> SwipeCreditCardViewController {
         return storyboard.viewController(withID: .RegisterCreditCard) as! SwipeCreditCardViewController
@@ -43,26 +44,16 @@ class SwipeCreditCardViewController: UIViewController, RegistrationSubController
         super.viewDidLoad()
         self.setInProgress(false)
 
-        let pleaseWaitMessage = "Please wait..."
-
-        cardHandler.userMessages
-            .startWith(pleaseWaitMessage)
-            .map { message in
-                if message.isEmpty {
-                    return pleaseWaitMessage
-                } else {
-                    return message
-                }
-            }
-            .bind(to: titleLabel.rx.text)
-            .disposed(by: rx.disposeBag)
-
         cardHandler.cardStatus
             .takeUntil(self.viewWillDisappear)
             .subscribe(onNext: { message in
                     self.cardStatusLabel.text = "Card Status: \(message)"
                     if message == "Got Card" {
                         self.setInProgress(true)
+                    }
+
+                    if message.hasPrefix("Card Flight Error") {
+                        self.processingLabel.text = "ERROR PROCESSING CARD - SEE ADMIN"
                     }
                 },
                 onError: { error in
@@ -75,13 +66,13 @@ class SwipeCreditCardViewController: UIViewController, RegistrationSubController
                     self.cardStatusLabel.text = "Card Status: completed"
 
                     if let card = self.cardHandler.card {
-                        self.cardName.value = card.cardInfo.cardholderName ?? ""
-                        self.cardLastDigits.value = card.cardInfo.lastFour ?? ""
+                        self.cardName.value = card.name
+                        self.cardLastDigits.value = card.last4
 
-                        self.cardToken.value = card.token
+                        self.cardToken.value = card.cardToken
 
                         if let newUser = self.navigationController?.fulfillmentNav().bidDetails.newUser {
-                            newUser.name.value = (newUser.name.value.isNilOrEmpty) ? card.cardInfo.cardholderName : newUser.name.value
+                            newUser.name.value = (newUser.name.value.isNilOrEmpty) ? card.name : newUser.name.value
                         }
                     }
                     
@@ -125,6 +116,7 @@ class SwipeCreditCardViewController: UIViewController, RegistrationSubController
 
     func setInProgress(_ show: Bool) {
         illustrationImageView.alpha = show ? 0.1 : 1
+        processingLabel.isHidden = !show
         spinner.isHidden = !show
     }
 

--- a/Kiosk/Storyboards/Fulfillment.storyboard
+++ b/Kiosk/Storyboards/Fulfillment.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="O1R-5R-23t">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="O1R-5R-23t">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -90,6 +90,7 @@
             <objects>
                 <navigationController modalPresentationStyle="formSheet" navigationBarHidden="YES" id="w8O-U4-lhE" customClass="FulfillmentNavigationController" customModule="Kiosk" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="PvK-mZ-4Jp">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -113,7 +114,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eOX-N9-Jb7" customClass="ORTagBasedAutoStackView">
-                                <rect key="frame" x="65" y="380" width="364" height="247"/>
+                                <rect key="frame" x="65" y="360" width="364" height="247"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="364" id="UL4-gx-Cbr"/>
@@ -121,7 +122,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current Bid:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y81-nV-kZl">
-                                <rect key="frame" x="495" y="96" width="93" height="21"/>
+                                <rect key="frame" x="495" y="76" width="93" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="YTn-hw-G5D"/>
                                     <constraint firstAttribute="width" constant="93" id="qtx-0r-of1"/>
@@ -131,7 +132,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Bid:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sft-xL-TDA">
-                                <rect key="frame" x="495" y="150" width="70" height="21"/>
+                                <rect key="frame" x="495" y="130" width="70" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="70" id="3tC-Uu-bZy"/>
                                     <constraint firstAttribute="height" constant="21" id="gdo-Y0-dTp"/>
@@ -141,7 +142,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$9,000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GS2-EK-4Nx" customClass="ARSerifLabel">
-                                <rect key="frame" x="590" y="86" width="160" height="42"/>
+                                <rect key="frame" x="590" y="66" width="160" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="Qjg-LN-ICy"/>
                                     <constraint firstAttribute="width" constant="160" id="tUh-uq-xdJ"/>
@@ -151,7 +152,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Place Your Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rpc-fW-Rbb" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="315" height="40"/>
+                                <rect key="frame" x="65" y="60" width="315" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="R8Q-ME-wyR"/>
                                     <constraint firstAttribute="width" constant="315" id="ilL-dO-Fu9"/>
@@ -161,7 +162,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dT1-U2-hie" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="558" width="255" height="50"/>
+                                <rect key="frame" x="495" y="538" width="255" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="R4e-aV-laq"/>
                                     <constraint firstAttribute="width" constant="255" id="R9Z-jy-D7b"/>
@@ -178,7 +179,7 @@
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="j5m-yL-j50" customClass="UIImageViewAligned">
-                                <rect key="frame" x="65" y="190" width="364" height="182"/>
+                                <rect key="frame" x="65" y="170" width="364" height="182"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" image="YES" keyboardKey="YES"/>
                                 </accessibility>
@@ -192,7 +193,7 @@
                                 </userDefinedRuntimeAttributes>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter $9,500 or more " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uVu-PR-0oJ">
-                                <rect key="frame" x="525" y="196" width="225" height="21"/>
+                                <rect key="frame" x="525" y="176" width="225" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="225" id="5Rn-uB-ZCW"/>
                                     <constraint firstAttribute="height" constant="21" id="kP3-FS-tu0"/>
@@ -202,7 +203,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="9,999,999" borderStyle="line" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UKQ-z8-PIR" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="570" y="138" width="180" height="44"/>
+                                <rect key="frame" x="570" y="118" width="180" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="180" id="JFk-UH-8dP"/>
                                     <constraint firstAttribute="height" constant="44" id="tXT-Im-gdd"/>
@@ -211,7 +212,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ybr-6E-470" customClass="CursorView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="732" y="145" width="18" height="30"/>
+                                <rect key="frame" x="732" y="125" width="18" height="30"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="7QN-tC-1xV"/>
@@ -219,7 +220,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bTG-in-woi" customClass="ARSansSerifLabel">
-                                <rect key="frame" x="578" y="139" width="54" height="42"/>
+                                <rect key="frame" x="578" y="119" width="54" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="2th-Mf-LhF"/>
                                     <constraint firstAttribute="width" constant="54" id="qun-gv-k7E"/>
@@ -229,7 +230,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bld-wj-1c6">
-                                <rect key="frame" x="518" y="628" width="114" height="32"/>
+                                <rect key="frame" x="518" y="608" width="114" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="114" id="J7U-qx-I7e"/>
                                     <constraint firstAttribute="height" constant="32" id="SqT-XU-mv5"/>
@@ -241,7 +242,7 @@
                                 </state>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A3C-Vo-Qhd" customClass="KeypadContainerView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="256" width="255" height="282"/>
+                                <rect key="frame" x="495" y="236" width="255" height="282"/>
                                 <color key="backgroundColor" red="0.80967282458563539" green="0.80967282458563539" blue="0.80967282458563539" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="StA-GG-cJE"/>
@@ -271,7 +272,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="and" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ic1-FX-iJp">
-                                <rect key="frame" x="495" y="634" width="23" height="21"/>
+                                <rect key="frame" x="495" y="614" width="23" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="JTC-RL-C5T"/>
                                     <constraint firstAttribute="width" constant="23" id="ZC6-Db-yQY"/>
@@ -281,7 +282,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XXj-no-bvA">
-                                <rect key="frame" x="629" y="612" width="145" height="32"/>
+                                <rect key="frame" x="629" y="592" width="145" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="32" id="urH-yI-4ni"/>
                                     <constraint firstAttribute="width" constant="145" id="wok-x7-rX9"/>
@@ -293,7 +294,7 @@
                                 </state>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="by bidding you accept the" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Nc-B4-Sow">
-                                <rect key="frame" x="495" y="618" width="153" height="21"/>
+                                <rect key="frame" x="495" y="598" width="153" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="h3v-Ry-79Q"/>
                                     <constraint firstAttribute="width" constant="153" id="nL5-0l-egD"/>
@@ -434,6 +435,12 @@
                                 <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="PROCESSING CREDIT CARD..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxS-TX-lPW">
+                                <rect key="frame" x="37" y="252" width="243" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" name="ITCAvantGardeDemiTrack03" family="ITCAvantGardeDemiTrack03" pointSize="15"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3kx-gQ-2K5" customClass="Spinner" customModule="Kiosk" customModuleProvider="target">
                                 <rect key="frame" x="129" y="281" width="40" height="40"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -446,6 +453,7 @@
                     <connections>
                         <outlet property="cardStatusLabel" destination="aHb-WU-8Ia" id="TBG-FV-OYK"/>
                         <outlet property="illustrationImageView" destination="RjO-Er-UMG" id="k2j-ud-N64"/>
+                        <outlet property="processingLabel" destination="mxS-TX-lPW" id="f7o-RI-Gbx"/>
                         <outlet property="spinner" destination="3kx-gQ-2K5" id="qNd-VG-O2Y"/>
                         <outlet property="titleLabel" destination="ZJ3-lq-NnT" id="6uz-yX-WYe"/>
                         <segue destination="b7X-gR-AEL" kind="push" identifier="RegisterCreditCardToPostal" id="lC0-vU-FuX"/>
@@ -469,7 +477,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Register to Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y4V-Js-ToI" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="345" height="41"/>
+                                <rect key="frame" x="65" y="60" width="345" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="345" id="chs-Zu-ifj"/>
                                     <constraint firstAttribute="height" constant="41" id="qdM-C2-QZC"/>
@@ -479,7 +487,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wLI-pF-J4Q">
-                                <rect key="frame" x="65" y="141" width="685" height="2"/>
+                                <rect key="frame" x="65" y="121" width="685" height="2"/>
                                 <color key="backgroundColor" red="0.8862745098" green="0.8862745098" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="LbD-qb-hJ1"/>
@@ -487,7 +495,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ciJ-4f-fQL" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="65" y="587" width="265" height="73"/>
+                                <rect key="frame" x="65" y="567" width="265" height="73"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Card Status:" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="375" translatesAutoresizingMaskIntoConstraints="NO" id="Er0-yC-3sc" customClass="ARSerifLabel">
                                         <rect key="frame" x="8" y="8" width="249" height="57"/>
@@ -504,7 +512,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="soj-Ua-Mah" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="535" y="600" width="255" height="60"/>
+                                <rect key="frame" x="535" y="580" width="255" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VSY-52-iWB" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
                                         <rect key="frame" x="111" y="8" width="107" height="57"/>
@@ -523,7 +531,7 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7NP-jX-VW3">
-                                <rect key="frame" x="65" y="175" width="449" height="485"/>
+                                <rect key="frame" x="65" y="155" width="449" height="485"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="485" id="SCI-1w-og3"/>
                                     <constraint firstAttribute="width" constant="449" id="gdf-Aj-H5z"/>
@@ -533,7 +541,7 @@
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" placeholderIntrinsicWidth="215" placeholderIntrinsicHeight="280" translatesAutoresizingMaskIntoConstraints="NO" id="mSI-YI-8GU" customClass="RegisterFlowView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="535" y="175" width="215" height="280"/>
+                                <rect key="frame" x="535" y="155" width="215" height="280"/>
                                 <color key="backgroundColor" red="1" green="0.74152541888448142" blue="0.81937699294223965" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="280" id="34A-cE-IYu"/>
@@ -541,7 +549,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dj6-cY-N6o" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="426" y="64" width="324" height="60"/>
+                                <rect key="frame" x="426" y="44" width="324" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616890000002" blue="0.72024004409999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="324" id="kVi-6v-q5i"/>
@@ -549,7 +557,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dyr-7D-eW1" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="535" y="557" width="215" height="50"/>
+                                <rect key="frame" x="535" y="537" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="OfR-Gb-YdQ"/>
@@ -610,7 +618,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Your Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z2W-8h-N8L" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="288" height="41"/>
+                                <rect key="frame" x="65" y="60" width="288" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="288" id="5Fo-hz-e8w"/>
                                     <constraint firstAttribute="height" constant="41" id="L9I-BA-YVX"/>
@@ -620,7 +628,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your mobile number or bidder number." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="0Od-3T-sgv" customClass="ARSerifLabel">
-                                <rect key="frame" x="58" y="168" width="298" height="76"/>
+                                <rect key="frame" x="58" y="148" width="298" height="76"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="298" id="p0a-3v-odj"/>
                                     <constraint firstAttribute="height" constant="76" id="rIJ-It-hAp"/>
@@ -630,7 +638,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j5y-rZ-EtN" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="554" width="255" height="50"/>
+                                <rect key="frame" x="495" y="534" width="255" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="65P-gN-6ON"/>
@@ -645,7 +653,7 @@
                                 </state>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pfn-Rj-RYO">
-                                <rect key="frame" x="65" y="139" width="685" height="2"/>
+                                <rect key="frame" x="65" y="119" width="685" height="2"/>
                                 <color key="backgroundColor" red="0.88627450980392153" green="0.88627450980392153" blue="0.88627450980392153" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="VZm-q3-36Z"/>
@@ -653,7 +661,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bbd-XN-mf0" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="600" width="255" height="60"/>
+                                <rect key="frame" x="495" y="580" width="255" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8aS-O2-9no" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
                                         <rect key="frame" x="28" y="8" width="72" height="57"/>
@@ -687,7 +695,7 @@
                                 </constraints>
                             </view>
                             <textField opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Fop-9s-JEM" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="179" width="255" height="44"/>
+                                <rect key="frame" x="495" y="159" width="255" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Bwq-rQ-3nk"/>
                                     <constraint firstAttribute="width" constant="255" id="cgN-Tv-daA"/>
@@ -696,7 +704,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XER-jS-BL4" customClass="CursorView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="740" y="185" width="2" height="32"/>
+                                <rect key="frame" x="740" y="165" width="2" height="32"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="2" id="WoS-6K-wzF"/>
@@ -704,7 +712,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Z7-af-FHL">
-                                <rect key="frame" x="65" y="544" width="184" height="43"/>
+                                <rect key="frame" x="65" y="524" width="184" height="43"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="184" id="IA7-rM-vzb"/>
                                     <constraint firstAttribute="height" constant="43" id="OZ7-Gr-M2C"/>
@@ -719,7 +727,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lt9-iY-FNp" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="426" y="64" width="324" height="60"/>
+                                <rect key="frame" x="426" y="44" width="324" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616893485347" blue="0.72024004409018083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="oNg-oh-8od"/>
@@ -727,7 +735,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wUI-V6-mkQ" customClass="KeypadContainerView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="252" width="255" height="282"/>
+                                <rect key="frame" x="495" y="232" width="255" height="282"/>
                                 <color key="backgroundColor" red="0.80967282460000001" green="0.80967282460000001" blue="0.80967282460000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="FVM-An-Jb3"/>
@@ -790,7 +798,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sFU-mI-0Wz" customClass="SecureTextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="214" width="255" height="44"/>
+                                <rect key="frame" x="495" y="194" width="255" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="E8Z-6e-d6J"/>
                                     <constraint firstAttribute="height" constant="44" id="RAs-P5-LC4"/>
@@ -799,7 +807,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your Artsy email and password" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="wKb-uI-ydX" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="170" width="298" height="76"/>
+                                <rect key="frame" x="65" y="150" width="298" height="76"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="76" id="7XP-gx-3JJ"/>
                                     <constraint firstAttribute="width" constant="298" id="Gjm-CS-6OP"/>
@@ -809,7 +817,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zSp-ka-p6m" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="294" width="255" height="50"/>
+                                <rect key="frame" x="495" y="274" width="255" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="BGr-4e-PmR"/>
@@ -821,7 +829,7 @@
                                 </state>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Your Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mwf-mx-o0D" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="277" height="41"/>
+                                <rect key="frame" x="65" y="60" width="277" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="277" id="b2f-Q8-RHe"/>
                                     <constraint firstAttribute="height" constant="41" id="bEm-X1-7qk"/>
@@ -831,7 +839,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UtC-5V-jyw">
-                                <rect key="frame" x="65" y="141" width="685" height="2"/>
+                                <rect key="frame" x="65" y="121" width="685" height="2"/>
                                 <color key="backgroundColor" red="0.8862745098" green="0.8862745098" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="685" id="N2g-Vg-sjj"/>
@@ -839,7 +847,7 @@
                                 </constraints>
                             </view>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Email" minimumFontSize="19" translatesAutoresizingMaskIntoConstraints="NO" id="bMc-Jh-nkF" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="165" width="255" height="44"/>
+                                <rect key="frame" x="495" y="145" width="255" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="9IU-Ga-XCB"/>
                                     <constraint firstAttribute="height" constant="44" id="Pu2-nq-Qh8"/>
@@ -848,7 +856,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cRB-GQ-mXf" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="600" width="255" height="60"/>
+                                <rect key="frame" x="495" y="580" width="255" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WST-rZ-7Zd" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
                                         <rect key="frame" x="15" y="8" width="107" height="57"/>
@@ -882,7 +890,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9hG-yj-way">
-                                <rect key="frame" x="625" y="259" width="125" height="37"/>
+                                <rect key="frame" x="625" y="239" width="125" height="37"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="37" id="BTo-6z-bq1"/>
                                     <constraint firstAttribute="width" constant="125" id="vyo-6i-7V3"/>
@@ -898,7 +906,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uPB-WM-yNR" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="426" y="73" width="324" height="60"/>
+                                <rect key="frame" x="426" y="53" width="324" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616890000002" blue="0.72024004409999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="324" id="MXM-Ip-42r"/>
@@ -906,7 +914,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TID-cZ-Oja">
-                                <rect key="frame" x="65" y="557" width="192" height="19"/>
+                                <rect key="frame" x="65" y="537" width="192" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="19" id="LEb-Mt-u1z"/>
                                     <constraint firstAttribute="width" constant="192" id="Ly3-xB-b6u"/>
@@ -975,7 +983,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Registration Complete" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ThI-e6-Ovh" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="283" width="411" height="41"/>
+                                <rect key="frame" x="65" y="263" width="411" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="411" id="9Lj-rl-4cX"/>
                                     <constraint firstAttribute="height" constant="41" id="fiD-t3-iek"/>
@@ -985,7 +993,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XzW-dO-Dol" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="357" y="273" width="331" height="60"/>
+                                <rect key="frame" x="357" y="253" width="331" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616890000002" blue="0.72024004409999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="UDF-o0-o40"/>
@@ -993,14 +1001,14 @@
                                 </constraints>
                             </view>
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="5Bd-va-Xyb">
-                                <rect key="frame" x="704" y="281" width="46" height="46"/>
+                                <rect key="frame" x="704" y="261" width="46" height="46"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="46" id="CwR-P5-JVR"/>
                                     <constraint firstAttribute="height" constant="46" id="SGk-bG-h6b"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pio-Vk-2mc" customClass="Spinner" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="712" y="289" width="30" height="30"/>
+                                <rect key="frame" x="712" y="269" width="30" height="30"/>
                                 <color key="backgroundColor" red="0.61744341489999999" green="0.84611775919999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="30" id="5SH-PU-dsE"/>
@@ -1008,7 +1016,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YtU-mx-Y9t" customClass="SecondaryActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="535" y="543.5" width="215" height="50"/>
+                                <rect key="frame" x="535" y="523.5" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="iX0-0O-uBH"/>
@@ -1023,7 +1031,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wub-hw-p5h" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="535" y="478.5" width="215" height="50"/>
+                                <rect key="frame" x="535" y="458.5" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="215" id="ccl-VO-0m2"/>
@@ -1038,7 +1046,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status message goes here." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="509" translatesAutoresizingMaskIntoConstraints="NO" id="Hxa-pm-Msp" customClass="ARSerifLabel">
-                                <rect key="frame" x="173" y="360.5" width="468" height="100"/>
+                                <rect key="frame" x="173" y="340.5" width="468" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="VcM-lT-yMM"/>
                                     <constraint firstAttribute="width" constant="468" id="ecb-VB-aUK"/>
@@ -1194,6 +1202,7 @@
                 <navigationController navigationBarHidden="YES" id="B8h-mi-lOQ" sceneMemberID="viewController">
                     <nil key="simulatedTopBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="GfH-jN-lKt">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -1239,7 +1248,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Your Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gqS-c0-RGC" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="395" height="41"/>
+                                <rect key="frame" x="65" y="60" width="395" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="395" id="lMJ-ah-n0d"/>
                                     <constraint firstAttribute="height" constant="41" id="uco-gz-3W4"/>
@@ -1249,7 +1258,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter PIN to authorize your bid." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="m6Z-l1-mnq" customClass="ARSerifLabel">
-                                <rect key="frame" x="58" y="168" width="298" height="76"/>
+                                <rect key="frame" x="58" y="148" width="298" height="76"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="298" id="gTR-E6-6rk"/>
                                     <constraint firstAttribute="height" constant="76" id="t8y-dd-Zmf"/>
@@ -1259,7 +1268,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qfw-xp-Fto" customClass="KeypadContainerView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="252" width="255" height="282"/>
+                                <rect key="frame" x="495" y="232" width="255" height="282"/>
                                 <color key="backgroundColor" red="0.80967282460000001" green="0.80967282460000001" blue="0.80967282460000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="35o-L4-jvt"/>
@@ -1267,7 +1276,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AQJ-hL-zxq">
-                                <rect key="frame" x="65" y="139" width="685" height="2"/>
+                                <rect key="frame" x="65" y="119" width="685" height="2"/>
                                 <color key="backgroundColor" red="0.8862745098" green="0.8862745098" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="685" id="AYI-lJ-Dp1"/>
@@ -1275,7 +1284,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R6q-Ds-JXn" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="554" width="255" height="50"/>
+                                <rect key="frame" x="495" y="534" width="255" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="d4r-9i-2b5"/>
@@ -1290,7 +1299,7 @@
                                 </state>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mrk-wa-iTP" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="603" width="255" height="60"/>
+                                <rect key="frame" x="495" y="583" width="255" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wV1-57-zip" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
                                         <rect key="frame" x="115" y="8" width="120" height="57"/>
@@ -1313,7 +1322,7 @@
                                 </constraints>
                             </view>
                             <textField opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="PIN" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="s7h-hd-xd3" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="495" y="176" width="255" height="44"/>
+                                <rect key="frame" x="495" y="156" width="255" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="USC-LB-e8O"/>
                                     <constraint firstAttribute="width" constant="255" id="YiJ-w4-ICO"/>
@@ -1322,7 +1331,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pHa-c1-dRf" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="426" y="64" width="324" height="60"/>
+                                <rect key="frame" x="426" y="44" width="324" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616890000002" blue="0.72024004409999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="DPI-hD-m3c"/>
@@ -1330,7 +1339,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dVe-25-8Zu">
-                                <rect key="frame" x="667" y="222" width="94" height="28"/>
+                                <rect key="frame" x="667" y="202" width="94" height="28"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="94" id="Bee-g5-X0E"/>
                                     <constraint firstAttribute="height" constant="28" id="xYc-3d-wNy"/>
@@ -1396,7 +1405,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Your Bid" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y3Z-48-2QM" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="80" width="334" height="41"/>
+                                <rect key="frame" x="65" y="60" width="334" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="41" id="45g-tf-GOg"/>
                                     <constraint firstAttribute="width" constant="334" id="6eb-cy-fN8"/>
@@ -1406,7 +1415,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your Email" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="298" translatesAutoresizingMaskIntoConstraints="NO" id="vEK-bj-ckg" customClass="ARSerifLabel">
-                                <rect key="frame" x="65" y="168" width="298" height="37"/>
+                                <rect key="frame" x="65" y="148" width="298" height="37"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="37" id="5AN-vN-g2d"/>
                                     <constraint firstAttribute="width" constant="298" id="Pre-XL-wp9"/>
@@ -1416,7 +1425,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C1g-Bf-QlT">
-                                <rect key="frame" x="65" y="139" width="685" height="2"/>
+                                <rect key="frame" x="65" y="119" width="685" height="2"/>
                                 <color key="backgroundColor" red="0.8862745098" green="0.8862745098" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="JFK-bK-cWo"/>
@@ -1424,7 +1433,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="co3-ck-sKp" customClass="DeveloperOnlyView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="406" y="603" width="349" height="60"/>
+                                <rect key="frame" x="406" y="583" width="349" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jm9-5W-0Q1" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
                                         <rect key="frame" x="177" y="8" width="164" height="57"/>
@@ -1458,7 +1467,7 @@
                                 </constraints>
                             </view>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="y4z-UB-ZdO" customClass="TextField" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="65" y="222" width="430" height="50"/>
+                                <rect key="frame" x="65" y="202" width="430" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="430" id="9WH-Z7-Aa9"/>
                                     <constraint firstAttribute="height" constant="50" id="Vcp-Dt-paq"/>
@@ -1467,7 +1476,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="go"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qef-T4-al0" customClass="BidDetailsPreviewView" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="426" y="61" width="324" height="60"/>
+                                <rect key="frame" x="426" y="41" width="324" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.90311616890000002" blue="0.72024004409999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="7Ah-yD-JXC"/>
@@ -1475,7 +1484,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AiP-vh-j1o" customClass="ActionButton" customModule="Kiosk" customModuleProvider="target">
-                                <rect key="frame" x="507" y="222" width="100" height="50"/>
+                                <rect key="frame" x="507" y="202" width="100" height="50"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.95686274510000002" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="gri-zi-8SG"/>
@@ -2128,10 +2137,15 @@
         <image name="CardSwipe" width="1923" height="1801"/>
         <image name="edit_button.png" width="64" height="64"/>
     </resources>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
+    </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
+        <segue reference="9X5-eM-AKF"/>
         <segue reference="hvW-mC-OYp"/>
         <segue reference="ccv-le-Cu0"/>
         <segue reference="eZu-3X-lXX"/>
-        <segue reference="9X5-eM-AKF"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Kiosk/Supporting Files/Info.plist
+++ b/Kiosk/Supporting Files/Info.plist
@@ -29,11 +29,22 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Credit Card Reader</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Credit Card Reader</string>
-	<key>UIAppFonts</key>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+        <key>UIAppFonts</key>
 	<array>
 		<string>AGaramondPro-BoldItalic.otf</string>
 		<string>AGaramondPro-Bold.otf</string>
@@ -42,23 +53,5 @@
 		<string>AVG65lig.otf</string>
 		<string>AGaramondPro-Semibold.otf</string>
 	</array>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UIStatusBarHidden</key>
-	<true/>
-	<key>UISupportedExternalAccessoryProtocols</key>
-	<array>
-		<string>com.miura.shuttle</string>
-		<string>com.cardflight.bold</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 </dict>
 </plist>

--- a/Kiosk/Supporting Files/PodsBridgingHeader.h
+++ b/Kiosk/Supporting Files/PodsBridgingHeader.h
@@ -17,6 +17,8 @@
 // Fonts can come from one of two Pods, but each has the same module/header name.
 #import <Artsy_UIFonts/UIFont+ArtsyFonts.h>
 
+#import "CardFlight.h"
+
 #import <UIImageViewAligned/UIImageViewAligned.h>
 #import <DZNWebViewController/DZNWebViewController.h>
 

--- a/KioskTests/Bid Fulfillment/KeypadViewModelTests.swift
+++ b/KioskTests/Bid Fulfillment/KeypadViewModelTests.swift
@@ -2,13 +2,26 @@ import Quick
 import Nimble
 import RxNimble
 import RxSwift
+import RxCocoa
 @testable
 import Kiosk
 
 class KeypadViewModelTestClass: NSObject {
     // Start with invalid data
-    var stringValue = Variable("something invalid")
-    var currencyValue = Variable<Currency>(0)
+    var _string = ""
+    lazy var stringValue: Binder<String> = {
+        return Binder<String>(self, binding: { (target, text) in
+            target._string = text
+            return
+        })
+    }()
+    var _currency = UInt64(0)
+    lazy var currencyValue: Binder<UInt64> = {
+        Binder<UInt64>(self, binding: { (target, currency) in
+            target._currency = currency
+            return
+        })
+    }()
 }
 
 class KeypadViewModelTests: QuickSpec {
@@ -35,8 +48,8 @@ class KeypadViewModelTests: QuickSpec {
         }
         
         it("it has default values") {
-            expect(testHarness.currencyValue.asObservable()).first == 0
-            expect(testHarness.stringValue.asObservable()).first == ""
+            expect(testHarness._currency) == 0
+            expect(testHarness._string) == ""
         }
         
         it("adds digits") {
@@ -46,8 +59,8 @@ class KeypadViewModelTests: QuickSpec {
                         observable.then { subject.addDigitAction.execute(input) }
                     })
                     .subscribe(onCompleted: {
-                        expect(testHarness.currencyValue.asObservable()).first == 1337
-                        expect(testHarness.stringValue.asObservable()).first == "1337"
+                        expect(testHarness._currency) == 1337
+                        expect(testHarness._string) == "1337"
 
                         done()
                     })
@@ -64,8 +77,8 @@ class KeypadViewModelTests: QuickSpec {
                         observable.then { subject.addDigitAction.execute(input) }
                     })
                     .subscribe(onCompleted: {
-                        expect(testHarness.currencyValue.asObservable()).first == 1333333
-                        expect(testHarness.stringValue.asObservable()).first == "1333333333337"
+                        expect(testHarness._currency) == 1333333
+                        expect(testHarness._string) == "1333333333337"
 
                         done()
                     })
@@ -80,8 +93,8 @@ class KeypadViewModelTests: QuickSpec {
                         observable.then { subject.addDigitAction.execute(input) }
                     })
                     .subscribe(onCompleted: {
-                        expect(testHarness.currencyValue.asObservable()).first == 1337
-                        expect(testHarness.stringValue.asObservable()).first == "01337"
+                        expect(testHarness._currency) == 1337
+                        expect(testHarness._string) == "01337"
                         
                         done()
                     })
@@ -99,8 +112,8 @@ class KeypadViewModelTests: QuickSpec {
                         subject.clearAction.execute(Void())
                     }
                     .subscribe(onCompleted: {
-                        expect(testHarness.currencyValue.asObservable()).first == 0
-                        expect(testHarness.stringValue.asObservable()).first == ""
+                        expect(testHarness._currency) == 0
+                        expect(testHarness._string) == ""
                         
                         done()
                     })
@@ -117,8 +130,8 @@ class KeypadViewModelTests: QuickSpec {
                     .then {
                         subject.deleteAction.execute(Void())
                     }.subscribe(onCompleted: {
-                        expect(testHarness.currencyValue.asObservable()).first == 13
-                        expect(testHarness.stringValue.asObservable()).first == "13"
+                        expect(testHarness._currency) == 13
+                        expect(testHarness._string) == "13"
 
                         done()
                     })

--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ target 'Kiosk' do
   pod 'ARAnalytics/Segmentio'
   pod 'ARAnalytics/HockeyApp'
 
-  pod 'CardFlight-v4'
+  pod 'CardFlight', '~> 3.0'
   pod 'Stripe'
   pod 'ECPhoneNumberFormatter'
   pod 'UIImageViewAligned', :git => 'https://github.com/ashfurrow/UIImageViewAligned.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
     - UIView+BooleanAnimations
-  - CardFlight-v4 (4.3.1)
+  - CardFlight (3.6.1)
   - DZNWebViewController (2.0):
     - NJKWebViewProgress (~> 0.2)
   - ECPhoneNumberFormatter (0.1.1)
@@ -95,7 +95,7 @@ DEPENDENCIES:
   - Artsy+UIFonts
   - Artsy+UILabels
   - Artsy-UIButtons
-  - CardFlight-v4
+  - CardFlight (~> 3.0)
   - DZNWebViewController (from `https://github.com/orta/DZNWebViewController.git`)
   - ECPhoneNumberFormatter
   - FBSnapshotTestCase
@@ -156,7 +156,7 @@ SPEC CHECKSUMS:
   Artsy+UIFonts: d38c82636e000b1dee31b7bec0268e1841dac17f
   Artsy+UILabels: 7cb6e290a4f70dddba037b7dbeb21e90b49d7275
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  CardFlight-v4: 2af173b8bc8b38d55bf150cd494dd7f59ba84dd9
+  CardFlight: 7b34237b6098c231d7a0066c3e38610ca3a98112
   DZNWebViewController: 54e8ee1c5bcc43e341ad77737631098d0d76db69
   ECPhoneNumberFormatter: 061041e7715f8d3f2e8e2a069ddf28c52f7bd314
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
@@ -187,6 +187,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 9ab3f08861431cedc335a74566f4ea088dff3a0b
+PODFILE CHECKSUM: 2ff62b50683ed6a54944375176b5748d3c8d7fa9
 
 COCOAPODS: 1.4.0


### PR DESCRIPTION
This PR unblocks work on our [Q4 Kiosk Updates](https://artsyproduct.atlassian.net/browse/PURCHASE-511).

This reverts #687. See [this Jira ticket](https://artsyproduct.atlassian.net/browse/PURCHASE-615) for more info. We need to build against Xcode 9 because Xcode 10 removes libstdc++.6.0.9 and CardFlight v3 requires it to link against. To that end, I'm merging into the `Xcode-9` branch, which can run parallel to `master` for now.

In the mean time, this PR also includes a fix for the initial problem that prompted me to upgrade to CardFlight 4: 
https://github.com/artsy/eidolon/commit/2a2a48f521c82add23de26dbdb746c71df7f9f2d