### PR TITLE
[PURCHASE-1292] Name entry fix for manual CC input

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,6 @@
 upcoming:
 - Fixes manual credit card input [ash]
+- User is prompted for full legal name when registering with manual CC input [ash]
 
 releases:
 - version: 5.10.0

--- a/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
+++ b/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
@@ -37,7 +37,9 @@ enum RegistrationIndex {
 
 class RegistrationCoordinator: NSObject {
     fileprivate lazy var _currentIndex: Variable<RegistrationIndex> = {
-        if (self.sale.bypassCreditCardRequirement) { // Access global state here, oops.
+        // Access global state here, oops. Normally we want to be "reactive", but this
+        // lazy prop only gets executed once.
+        if (self.requireFullNameEntry) {
             return Variable(.nameVC)
         } else {
             return Variable(.mobileVC)
@@ -45,9 +47,15 @@ class RegistrationCoordinator: NSObject {
     }()
     // sale is used only for _currentIndex, and is readwrite for unit testing purposes.
     lazy var sale: Sale! = appDelegate().sale
+    lazy var appSetup: AppSetup = AppSetup.sharedState
     var currentIndex: Observable<RegistrationIndex> {
         return _currentIndex.asObservable().distinctUntilChanged()
     }
+
+    fileprivate var requireFullNameEntry: Bool {
+        return sale.bypassCreditCardRequirement || appSetup.disableCardReader
+    }
+
     var storyboard: UIStoryboard!
 
     func viewControllerForIndex(_ index: RegistrationIndex) -> UIViewController {
@@ -65,7 +73,7 @@ class RegistrationCoordinator: NSObject {
         case .zipCodeVC:
             return storyboard.viewController(withID: .RegisterPostalorZip)
         case .creditCardVC:
-            if AppSetup.sharedState.disableCardReader {
+            if appSetup.disableCardReader {
                 return storyboard.viewController(withID: .ManualCardDetailsInput)
             } else {
                 return storyboard.viewController(withID: .RegisterCreditCard)
@@ -76,7 +84,7 @@ class RegistrationCoordinator: NSObject {
     }
 
     func nextViewControllerForBidDetails(_ details: BidDetails, sale: Sale) -> UIViewController {
-        if (sale.bypassCreditCardRequirement) {
+        if (self.requireFullNameEntry) {
             if notSet(details.newUser.name.value) {
                 return viewControllerForIndex(.nameVC)
             }
@@ -94,7 +102,7 @@ class RegistrationCoordinator: NSObject {
             return viewControllerForIndex(.passwordVC)
         }
 
-        if notSet(details.newUser.zipCode.value) && AppSetup.sharedState.needsZipCode {
+        if notSet(details.newUser.zipCode.value) && appSetup.needsZipCode {
             return viewControllerForIndex(.zipCodeVC)
         }
         

--- a/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
+++ b/Kiosk/Bid Fulfillment/Models/RegistrationCoordinator.swift
@@ -45,7 +45,7 @@ class RegistrationCoordinator: NSObject {
             return Variable(.mobileVC)
         }
     }()
-    // sale is used only for _currentIndex, and is readwrite for unit testing purposes.
+    // This is readwrite for unit testing purposes only.
     lazy var sale: Sale! = appDelegate().sale
     lazy var appSetup: AppSetup = AppSetup.sharedState
     var currentIndex: Observable<RegistrationIndex> {
@@ -83,7 +83,7 @@ class RegistrationCoordinator: NSObject {
         }
     }
 
-    func nextViewControllerForBidDetails(_ details: BidDetails, sale: Sale) -> UIViewController {
+    func nextViewControllerForBidDetails(_ details: BidDetails) -> UIViewController {
         if (self.requireFullNameEntry) {
             if notSet(details.newUser.name.value) {
                 return viewControllerForIndex(.nameVC)

--- a/Kiosk/Bid Fulfillment/RegisterViewController.swift
+++ b/Kiosk/Bid Fulfillment/RegisterViewController.swift
@@ -74,7 +74,7 @@ class RegisterViewController: UIViewController {
     }
 
     func goToNextVC() {
-        let nextVC = coordinator.nextViewControllerForBidDetails(fulfillmentNav().bidDetails, sale: sale)
+        let nextVC = coordinator.nextViewControllerForBidDetails(fulfillmentNav().bidDetails)
         goToViewController(nextVC)
     }
 

--- a/KioskTests/Models/RegistrationCoordinatorTests.swift
+++ b/KioskTests/Models/RegistrationCoordinatorTests.swift
@@ -6,14 +6,13 @@ import Kiosk
 
 class RegistrationCoordinatorTests: QuickSpec {
     override func spec() {
-        var sale: Sale!
         var bidDetails: BidDetails!
         var subject: RegistrationCoordinator!
         
         beforeEach {
             bidDetails = testBidDetails()
             bidDetails.newUser = NewUser()
-            sale = makeSale()
+            let sale = makeSale()
             subject = RegistrationCoordinator()
             subject.storyboard = fulfillmentStoryboard
             subject.appSetup = AppSetup.sharedState
@@ -24,13 +23,13 @@ class RegistrationCoordinatorTests: QuickSpec {
         describe("nextViewControllerForBidDetails") {
             describe("with CC reader enabled on the device") {
                 it("defaults to the mobile VC") {
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationMobileViewController.self) )
                 }
 
                 it("moves onto email after mobile") {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationEmailViewController.self) )
                 }
 
@@ -38,7 +37,7 @@ class RegistrationCoordinatorTests: QuickSpec {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
                     bidDetails.newUser.email.value = "test@example.com"
                     bidDetails.bidderPIN.value = nil
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationPasswordViewController.self) )
                 }
             }
@@ -49,20 +48,20 @@ class RegistrationCoordinatorTests: QuickSpec {
                 }
 
                 it("defaults to the name VC") {
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationNameViewController.self) )
                 }
 
                 it("moves onto mobile after name") {
                     bidDetails.newUser.name.value = "Fname Lname"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationMobileViewController.self) )
                 }
 
                 it("moves onto email after mobile") {
                     bidDetails.newUser.name.value = "Fname Lname"
                     bidDetails.newUser.phoneNumber.value = "5555555555"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationEmailViewController.self) )
                 }
 
@@ -71,7 +70,7 @@ class RegistrationCoordinatorTests: QuickSpec {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
                     bidDetails.newUser.email.value = "test@example.com"
                     bidDetails.bidderPIN.value = nil
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationPasswordViewController.self) )
                 }
             }
@@ -82,7 +81,7 @@ class RegistrationCoordinatorTests: QuickSpec {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
                     bidDetails.newUser.email.value = "test@example.com"
                     bidDetails.newUser.password.value = "password"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(SwipeCreditCardViewController.self) )
                 }
             }
@@ -92,30 +91,29 @@ class RegistrationCoordinatorTests: QuickSpec {
                 bidDetails.newUser.email.value = "test@example.com"
                 bidDetails.newUser.password.value = "password"
                 bidDetails.newUser.creditCardToken.value = "abcdefg123456"
-                let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                let vc = subject.nextViewControllerForBidDetails(bidDetails)
                 expect(vc).to( beAKindOf(UIViewController.self) )
             }
 
             it("sets the new index on the coordinator") {
                 bidDetails.newUser.phoneNumber.value = "5555555555"
-                _ = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                _ = subject.nextViewControllerForBidDetails(bidDetails)
                 expect(subject.currentIndex).first == RegistrationIndex.emailVC
             }
 
             describe("with swipeless sale") {
                 beforeEach {
-                    sale = makeSale(bypassCreditCardRequirement: true)
-                    subject.sale = sale
+                    subject.sale = makeSale(bypassCreditCardRequirement: true)
                 }
 
                 it("defaults to the name VC") {
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationNameViewController.self) )
                 }
 
                 it("moves onto the mobile after name") {
                     bidDetails.newUser.name.value = "Fname Lname"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(RegistrationMobileViewController.self) )
                 }
 
@@ -123,7 +121,7 @@ class RegistrationCoordinatorTests: QuickSpec {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
                     bidDetails.newUser.email.value = "test@example.com"
                     bidDetails.newUser.password.value = "password"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).notTo( beAKindOf(SwipeCreditCardViewController.self) )
                 }
 
@@ -131,7 +129,7 @@ class RegistrationCoordinatorTests: QuickSpec {
                     bidDetails.newUser.phoneNumber.value = "5555555555"
                     bidDetails.newUser.email.value = "test@example.com"
                     bidDetails.newUser.password.value = "password"
-                    let vc = subject.nextViewControllerForBidDetails(bidDetails, sale: sale)
+                    let vc = subject.nextViewControllerForBidDetails(bidDetails)
                     expect(vc).to( beAKindOf(UIViewController.self) )
                 }
             }


### PR DESCRIPTION
This PR follows-up on #708. That PR had the "name" view present in the side bar, but the user was never actually _asked_ for their name.

That's because we're calculating whether or not the "name" should be asked for in two places: 

- Where the side bar UI is rendered.
- Where the user is guided through our registration flow (the `RegistrationCoordinator` class).

Ideally we would only have this calculated once, but it's a larger refactor than I want to take on right now. I did, however, clean up the `nextViewControllerForBidDetails` function to no longer take a `sale` param (because `RegistrationCoordinator` already has a `sale` property).