### PR TITLE
change public spec source to CDN

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
-source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/artsy/Specs.git'
+source 'https://cdn.cocoapods.org/'
 
 plugin 'cocoapods-keys', {
   :project => 'Eidolon',


### PR DESCRIPTION
You should use CDN for public pod spec after cocoapods 1.7.2