### PR TITLE
fix: handles nil fonts correctly for OSS contributors #trivial

### DIFF
--- a/Kiosk/App/Models/Artwork.swift
+++ b/Kiosk/App/Models/Artwork.swift
@@ -94,12 +94,12 @@ import SwiftyJSON
 private func titleAndDateAttributedString(_ title: String, dateString: String) -> NSAttributedString {
     let workTitle = title.isEmpty ? "Untitled" : title
 
-    let workFont = UIFont.serifItalicFont(withSize: 16)!
-    let attributedString = NSMutableAttributedString(string: workTitle, attributes: [NSAttributedStringKey.font : workFont])
+    let workFont: UIFont? = UIFont.serifItalicFont(withSize: 16)
+    let attributedString = NSMutableAttributedString(string: workTitle, attributes: workFont == nil ? nil : [NSAttributedStringKey.font : workFont!])
     
     if dateString.isNotEmpty {
-        let dateFont = UIFont.serifFont(withSize: 16)!
-        let dateString = NSAttributedString(string: ", " + dateString, attributes: [NSAttributedStringKey.font : dateFont])
+        let dateFont: UIFont? = UIFont.serifFont(withSize: 16)
+        let dateString = NSAttributedString(string: ", " + dateString, attributes: dateFont == nil ? nil : [NSAttributedStringKey.font : dateFont!])
         attributedString.append(dateString)
     }
     


### PR DESCRIPTION
An open source contributor [brought up a problem](https://github.com/ashfurrow/xcode-hardware-performance/pull/137#issue-527887411) where the OSS font-loading wasn't working (ie: the font is returning `nil`) and our code does not expect that. I tried debugging this but the iOS font pod closed-vs-open fonts are notoriously hard for Artsy staff to debug because of how we determine if someone "should" have the closed fonts ([see code here](https://github.com/artsy/Artsy-OSSUIFonts/blob/master/Pod/Scripts/ArtsySetup.rb)). So instead, I looked for places where we were force-unwrapping these fonts and added code to make sure that we handle the `nil`s correctly.

CI might not pass on this but the PR should be safe to merge – I tested locally.

/cc @jlnr @ondrejhanak 